### PR TITLE
Add mach_vm API and required dependencies

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,5 +14,6 @@ pub mod thread_act;
 pub mod thread_status;
 pub mod traps;
 pub mod types;
+pub mod vm_inherit;
 pub mod vm_prot;
 pub mod vm_types;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,7 @@ pub mod thread_act;
 pub mod thread_status;
 pub mod traps;
 pub mod types;
+pub mod vm_behavior;
 pub mod vm_inherit;
 pub mod vm_prot;
 pub mod vm_types;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,6 +19,7 @@ pub mod vm_attributes;
 pub mod vm_behavior;
 pub mod vm_inherit;
 pub mod vm_prot;
+pub mod vm_purgable;
 pub mod vm_region;
 pub mod vm_sync;
 pub mod vm_types;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,4 +14,5 @@ pub mod thread_act;
 pub mod thread_status;
 pub mod traps;
 pub mod types;
+pub mod vm_prot;
 pub mod vm_types;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,4 +19,5 @@ pub mod vm_behavior;
 pub mod vm_inherit;
 pub mod vm_prot;
 pub mod vm_region;
+pub mod vm_sync;
 pub mod vm_types;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,6 +15,7 @@ pub mod thread_act;
 pub mod thread_status;
 pub mod traps;
 pub mod types;
+pub mod vm_attributes;
 pub mod vm_behavior;
 pub mod vm_inherit;
 pub mod vm_prot;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,7 @@ extern crate libc;
 pub mod boolean;
 pub mod clock_types;
 pub mod kern_return;
+pub mod memory_object_types;
 pub mod message;
 pub mod port;
 pub mod structs;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,4 +18,5 @@ pub mod types;
 pub mod vm_behavior;
 pub mod vm_inherit;
 pub mod vm_prot;
+pub mod vm_region;
 pub mod vm_types;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,6 +15,7 @@ pub mod thread_act;
 pub mod thread_status;
 pub mod traps;
 pub mod types;
+pub mod vm;
 pub mod vm_attributes;
 pub mod vm_behavior;
 pub mod vm_inherit;

--- a/src/memory_object_types.rs
+++ b/src/memory_object_types.rs
@@ -1,0 +1,9 @@
+//! This module roughly corresponds to `mach/memory_object_types.h`.
+
+use vm_types::{natural_t};
+
+pub type memory_object_offset_t = ::libc::c_ulonglong;
+pub type memory_object_size_t = ::libc::c_ulonglong;
+pub type memory_object_cluster_size_t = natural_t;
+pub type memory_object_fault_info_t = *mut natural_t;
+pub type vm_object_id_t = ::libc::c_ulonglong;

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -1,0 +1,184 @@
+//! This module roughly corresponds to `mach/mach_vm.defs`.
+
+use boolean::{boolean_t};
+use kern_return::{kern_return_t};
+use memory_object_types::{memory_object_offset_t, memory_object_size_t};
+use message::{mach_msg_type_number_t};
+use port::{mach_port_t};
+use types::{mem_entry_name_port_t, vm_task_entry_t};
+use vm_attributes::{vm_machine_attribute_t, vm_machine_attribute_val_t};
+use vm_behavior::{vm_behavior_t};
+use vm_inherit::{vm_inherit_t};
+use vm_prot::{vm_prot_t};
+use vm_purgable::{vm_purgable_t};
+use vm_region::*;
+use vm_sync::{vm_sync_t};
+use vm_types::*;
+
+extern "C" {
+    pub fn mach_vm_allocate(target: vm_task_entry_t,
+                            address: *mut mach_vm_address_t,
+                            size: mach_vm_size_t,
+                            flags: ::libc::c_int) -> kern_return_t;
+
+    pub fn mach_vm_deallocate(target: vm_task_entry_t,
+                              address: mach_vm_address_t,
+                              size: mach_vm_size_t) -> kern_return_t;
+
+    pub fn mach_vm_protect(target_task: vm_task_entry_t,
+                           address: mach_vm_address_t,
+                           size: mach_vm_size_t,
+                           set_maximum: boolean_t,
+                           new_protection: vm_prot_t) -> kern_return_t;
+
+    pub fn mach_vm_inherit(target_task: vm_task_entry_t,
+                           address: mach_vm_address_t,
+                           size: mach_vm_size_t,
+                           new_inheritance: vm_inherit_t) -> kern_return_t;
+
+    pub fn mach_vm_read(target_task: vm_task_entry_t,
+                        address: mach_vm_address_t,
+                        size: mach_vm_size_t,
+                        data: *mut vm_offset_t,
+                        dataCnt: *mut mach_msg_type_number_t) -> kern_return_t;
+
+    pub fn mach_vm_read_list(target_task: vm_task_entry_t,
+                             data_list: mach_vm_read_entry_t,
+                             count: natural_t) -> kern_return_t;
+
+    pub fn mach_vm_write(target_task: vm_task_entry_t,
+                         address: mach_vm_address_t,
+                         data: vm_offset_t,
+                         dataCnt: mach_msg_type_number_t);
+
+    pub fn mach_vm_copy(target_task: vm_task_entry_t,
+                        source_address: mach_vm_address_t,
+                        size: mach_vm_size_t,
+                        dest_address: mach_vm_address_t) -> kern_return_t;
+
+    pub fn mach_vm_read_overwrite(target_task: vm_task_entry_t,
+                                  address: mach_vm_address_t,
+                                  size: mach_vm_size_t,
+                                  data: mach_vm_address_t,
+                                  outsize: *mut mach_vm_size_t) -> kern_return_t;
+
+    pub fn mach_vm_msync(target_task: vm_task_entry_t,
+                         address: mach_vm_address_t,
+                         size: mach_vm_size_t,
+                         sync_flags: vm_sync_t) -> kern_return_t;
+
+    pub fn mach_vm_behavior_set(target_task: vm_task_entry_t,
+                                address: mach_vm_address_t,
+                                size: mach_vm_size_t,
+                                new_behavior: vm_behavior_t) -> kern_return_t;
+
+    pub fn mach_vm_map(target_task: vm_task_entry_t,
+                       inout: mach_vm_address_t,
+                       size: mach_vm_size_t,
+                       mask: mach_vm_offset_t,
+                       flags: ::libc::c_int,
+                       object: mem_entry_name_port_t,
+                       offset: memory_object_offset_t,
+                       copy: boolean_t,
+                       cur_protection: vm_prot_t,
+                       max_protection: vm_prot_t,
+                       inheritance: vm_inherit_t) -> kern_return_t;
+
+    pub fn mach_vm_machine_attribute(target_task: vm_task_entry_t,
+                                     address: mach_vm_address_t,
+                                     size: mach_vm_size_t,
+                                     attribute: vm_machine_attribute_t,
+                                     value: *mut vm_machine_attribute_val_t) -> kern_return_t;
+
+    pub fn mach_vm_remap(target_task: vm_task_entry_t,
+                         target_address: *mut mach_vm_address_t,
+                         size: mach_vm_size_t,
+                         mask: mach_vm_offset_t,
+                         flags: ::libc::c_int,
+                         src_task: vm_task_entry_t,
+                         src_address: mach_vm_address_t,
+                         copy: boolean_t,
+                         cur_protection: *mut vm_prot_t,
+                         out: *mut vm_prot_t,
+                         inheritance: vm_inherit_t) -> kern_return_t;
+
+    // TODO: Implement 'vm_page.h' (contains definition for vm_map_t)
+    //pub fn mach_vm_page_query(target_map: vm_map_t,
+    //                          offset: mach_vm_offset_t,
+    //                          disposition: *mut integer_t,
+    //                          ref_count: *mut integer_t) -> kern_return_t;
+
+    pub fn mach_vm_region_recurse(target_task: vm_task_entry_t,
+                                  address: *mut mach_vm_address_t,
+                                  size: *mut mach_vm_size_t,
+                                  nesting_depth: *mut natural_t,
+                                  info: vm_region_recurse_info_t,
+                                  infoCnt: *mut mach_msg_type_number_t) -> kern_return_t;
+
+    pub fn mach_vm_region(target_task: vm_task_entry_t,
+                          address: *mut mach_vm_address_t,
+                          size: *mut mach_vm_size_t,
+                          flavor: vm_region_flavor_t,
+                          info: vm_region_info_t,
+                          infoCnt: *mut mach_msg_type_number_t,
+                          object_name: *mut mach_port_t) -> kern_return_t;
+
+    pub fn mach_make_memory_entry(target_task: vm_task_entry_t,
+                                  size: *mut memory_object_size_t,
+                                  offset: memory_object_offset_t,
+                                  permission: vm_prot_t,
+                                  object_handle: *mut mem_entry_name_port_t,
+                                  parent_handle: mem_entry_name_port_t) -> kern_return_t;
+
+    pub fn mach_vm_purgable_control(target_task: vm_task_entry_t,
+                                    address: mach_vm_address_t,
+                                    control: vm_purgable_t,
+                                    state: *mut ::libc::c_int) -> kern_return_t;
+
+    pub fn mach_vm_page_info(target_task: vm_task_entry_t,
+                             address: mach_vm_address_t,
+                             flavor: vm_page_info_flavor_t,
+                             info: vm_page_info_t,
+                             infoCnt: *mut mach_msg_type_number_t) -> kern_return_t;
+}
+
+#[test]
+fn mach_vm_allocate_sanity_test() {
+    use kern_return::*;
+    use traps::mach_task_self;
+
+    unsafe {
+        let size = 0x100;
+        let task = mach_task_self();
+
+        let mut address: mach_vm_address_t = 0;
+        assert_eq!(mach_vm_allocate(task, &mut address, size, 1), KERN_SUCCESS);
+        println!("0x{:x}", address);
+        assert_eq!(mach_vm_deallocate(task, address, size), KERN_SUCCESS);
+    }
+}
+
+#[test]
+fn mach_vm_region_sanity_test() {
+    use kern_return::*;
+    use traps::mach_task_self;
+    use vm_prot::*;
+
+    unsafe {
+        let mut size = 0x10;
+        let mut object_name = 0;
+        let mut address = mach_vm_region_sanity_test as mach_vm_address_t;
+        let mut info: vm_region_basic_info_64 = ::std::mem::zeroed();
+        let mut info_size = vm_region_basic_info_64::count();
+
+        let result = mach_vm_region(mach_task_self(),
+                                    &mut address,
+                                    &mut size,
+                                    VM_REGION_BASIC_INFO_64,
+                                    (&mut info as *mut _) as vm_region_info_t,
+                                    &mut info_size,
+                                    &mut object_name);
+        assert_eq!(result, KERN_SUCCESS);
+        assert_eq!(info.protection, VM_PROT_READ | VM_PROT_EXECUTE);
+    }
+}

--- a/src/vm_attributes.rs
+++ b/src/vm_attributes.rs
@@ -1,0 +1,18 @@
+//! This module corresponds to `mach/vm_attributes.h`.
+
+pub type vm_machine_attribute_t = ::libc::c_uint;
+
+pub const MATTR_CACHE: vm_machine_attribute_t     = (1 << 0);
+pub const MATTR_MIGRATE: vm_machine_attribute_t   = (1 << 1);
+pub const MATTR_REPLICATE: vm_machine_attribute_t = (1 << 2);
+
+pub type vm_machine_attribute_val_t = ::libc::c_int;
+
+pub const MATTR_VAL_OFF: vm_machine_attribute_val_t          = 0;
+pub const MATTR_VAL_ON: vm_machine_attribute_val_t           = 1;
+pub const MATTR_VAL_GET: vm_machine_attribute_val_t          = 2;
+pub const MATTR_VAL_CACHE_FLUSH: vm_machine_attribute_val_t  = 6;
+pub const MATTR_VAL_DCACHE_FLUSH: vm_machine_attribute_val_t = 7;
+pub const MATTR_VAL_ICACHE_FLUSH: vm_machine_attribute_val_t = 8;
+pub const MATTR_VAL_CACHE_SYNC: vm_machine_attribute_val_t   = 9;
+pub const MATTR_VAL_GET_INFO: vm_machine_attribute_val_t     = 10;

--- a/src/vm_behavior.rs
+++ b/src/vm_behavior.rs
@@ -1,0 +1,15 @@
+//! This module corresponds to `mach/vm_behavior.h`.
+
+pub type vm_behavior_t = ::libc::c_int;
+
+pub const VM_BEHAVIOR_DEFAULT: vm_behavior_t          = 0;
+pub const VM_BEHAVIOR_RANDOM: vm_behavior_t           = 1;
+pub const VM_BEHAVIOR_SEQUENTIAL: vm_behavior_t       = 2;
+pub const VM_BEHAVIOR_RSEQNTL: vm_behavior_t          = 3;
+pub const VM_BEHAVIOR_WILLNEED: vm_behavior_t         = 4;
+pub const VM_BEHAVIOR_DONTNEED: vm_behavior_t         = 5;
+pub const VM_BEHAVIOR_FREE: vm_behavior_t             = 6;
+pub const VM_BEHAVIOR_ZERO_WIRED_PAGES: vm_behavior_t = 7;
+pub const VM_BEHAVIOR_REUSABLE: vm_behavior_t         = 8;
+pub const VM_BEHAVIOR_REUSE: vm_behavior_t            = 9;
+pub const VM_BEHAVIOR_CAN_REUSE: vm_behavior_t        = 10;

--- a/src/vm_inherit.rs
+++ b/src/vm_inherit.rs
@@ -1,0 +1,10 @@
+//! This module corresponds to `mach/vm_inherit.h`.
+
+pub type vm_inherit_t = ::libc::c_uint;
+
+pub const VM_INHERIT_SHARE: vm_inherit_t       = 0;
+pub const VM_INHERIT_COPY: vm_inherit_t        = 1;
+pub const VM_INHERIT_NONE: vm_inherit_t        = 2;
+pub const VM_INHERIT_DONATE_COPY: vm_inherit_t = 3;
+pub const VM_INHERIT_DEFAULT: vm_inherit_t     = VM_INHERIT_COPY;
+pub const VM_INHERIT_LAST_VALID: vm_inherit_t  = VM_INHERIT_NONE;

--- a/src/vm_prot.rs
+++ b/src/vm_prot.rs
@@ -1,0 +1,14 @@
+//! This module corresponds to `mach/vm_prot.h`.
+
+pub type vm_prot_t = ::libc::c_int;
+
+pub const VM_PROT_NONE: vm_prot_t       = 0;
+pub const VM_PROT_READ: vm_prot_t       = (1 << 0);
+pub const VM_PROT_WRITE: vm_prot_t      = (1 << 1);
+pub const VM_PROT_EXECUTE: vm_prot_t    = (1 << 2);
+pub const VM_PROT_NO_CHANGE: vm_prot_t  = (1 << 3);
+pub const VM_PROT_COPY: vm_prot_t       = (1 << 4);
+pub const VM_PROT_WANTS_COPY: vm_prot_t = (1 << 4);
+pub const VM_PROT_TRUSTED: vm_prot_t    = (1 << 5);
+pub const VM_PROT_DEFAULT: vm_prot_t    = VM_PROT_READ | VM_PROT_WRITE;
+pub const VM_PROT_ALL: vm_prot_t        = VM_PROT_READ | VM_PROT_WRITE | VM_PROT_EXECUTE;

--- a/src/vm_purgable.rs
+++ b/src/vm_purgable.rs
@@ -1,0 +1,42 @@
+//! This module corresponds to `mach/vm_purgable.h`.
+
+pub type vm_purgable_t = ::libc::c_int;
+
+pub const VM_PURGABLE_SET_STATE: vm_purgable_t = 0;
+pub const VM_PURGABLE_GET_STATE: vm_purgable_t = 1;
+
+pub const VM_VOLATILE_GROUP_SHIFT: ::libc::c_int   = 8;
+pub const VM_VOLATILE_GROUP_MASK: ::libc::c_int    = (7 << VM_VOLATILE_GROUP_SHIFT);
+pub const VM_VOLATILE_GROUP_DEFAULT: ::libc::c_int = VM_VOLATILE_GROUP_7;
+
+pub const VM_VOLATILE_GROUP_0: ::libc::c_int = (0 << VM_VOLATILE_GROUP_SHIFT);
+pub const VM_VOLATILE_GROUP_1: ::libc::c_int = (1 << VM_VOLATILE_GROUP_SHIFT);
+pub const VM_VOLATILE_GROUP_2: ::libc::c_int = (2 << VM_VOLATILE_GROUP_SHIFT);
+pub const VM_VOLATILE_GROUP_3: ::libc::c_int = (3 << VM_VOLATILE_GROUP_SHIFT);
+pub const VM_VOLATILE_GROUP_4: ::libc::c_int = (4 << VM_VOLATILE_GROUP_SHIFT);
+pub const VM_VOLATILE_GROUP_5: ::libc::c_int = (5 << VM_VOLATILE_GROUP_SHIFT);
+pub const VM_VOLATILE_GROUP_6: ::libc::c_int = (6 << VM_VOLATILE_GROUP_SHIFT);
+pub const VM_VOLATILE_GROUP_7: ::libc::c_int = (7 << VM_VOLATILE_GROUP_SHIFT);
+
+pub const VM_PURGABLE_BEHAVIOR_SHIFT: ::libc::c_int = 6;
+pub const VM_PURGABLE_BEHAVIOR_MASK: ::libc::c_int  = (1 << VM_PURGABLE_BEHAVIOR_SHIFT);
+pub const VM_PURGABLE_BEHAVIOR_FIFO: ::libc::c_int  = (0 << VM_PURGABLE_BEHAVIOR_SHIFT);
+pub const VM_PURGABLE_BEHAVIOR_LIFO: ::libc::c_int  = (1 << VM_PURGABLE_BEHAVIOR_SHIFT);
+
+pub const VM_PURGABLE_ORDERING_SHIFT: ::libc::c_int    = 5;
+pub const VM_PURGABLE_ORDERING_MASK: ::libc::c_int     = (1 << VM_PURGABLE_ORDERING_SHIFT);
+pub const VM_PURGABLE_ORDERING_OBSOLETE: ::libc::c_int = (1 << VM_PURGABLE_ORDERING_SHIFT);
+pub const VM_PURGABLE_ORDERING_NORMAL: ::libc::c_int   = (0 << VM_PURGABLE_ORDERING_SHIFT);
+
+pub const VM_VOLATILE_ORDER_SHIFT: ::libc::c_int         = 4;
+pub const VM_VOLATILE_ORDER_MASK: ::libc::c_int          = (1 << VM_VOLATILE_ORDER_SHIFT);
+pub const VM_VOLATILE_MAKE_FIRST_IN_GROUP: ::libc::c_int = (1 << VM_VOLATILE_ORDER_SHIFT);
+pub const VM_VOLATILE_MAKE_LAST_IN_GROUP: ::libc::c_int  = (0 << VM_VOLATILE_ORDER_SHIFT);
+
+pub const VM_PURGABLE_STATE_MIN: ::libc::c_int   = 0;
+pub const VM_PURGABLE_STATE_MAX: ::libc::c_int   = 3;
+pub const VM_PURGABLE_STATE_MASK: ::libc::c_int  = 3;
+pub const VM_PURGABLE_NONVOLATILE: ::libc::c_int = 0;
+pub const VM_PURGABLE_VOLATILE: ::libc::c_int    = 1;
+pub const VM_PURGABLE_EMPTY: ::libc::c_int       = 2;
+pub const VM_PURGABLE_DENY: ::libc::c_int        = 3;

--- a/src/vm_region.rs
+++ b/src/vm_region.rs
@@ -1,0 +1,237 @@
+//! This module roughly corresponds to `mach/vm_region.h`.
+
+use std::mem;
+
+use boolean::{boolean_t};
+use memory_object_types::{memory_object_offset_t, vm_object_id_t};
+use message::{mach_msg_type_number_t};
+use vm_behavior::{vm_behavior_t};
+use vm_inherit::{vm_inherit_t};
+use vm_prot::{vm_prot_t};
+use vm_types::{mach_vm_address_t, mach_vm_size_t};
+
+pub type vm32_object_id_t = ::libc::uint32_t;
+
+pub type vm_region_info_t = *mut ::libc::c_int;
+pub type vm_region_info_64_t = *mut ::libc::c_int;
+pub type vm_region_recurse_info_t = *mut ::libc::c_int;
+pub type vm_region_recurse_info_64_t = *mut ::libc::c_int;
+pub type vm_region_flavor_t = ::libc::c_int;
+pub type vm_region_info_data_t = [::libc::c_int; VM_REGION_INFO_MAX as usize];
+pub type vm_region_basic_info_64_t = *mut vm_region_basic_info_64;
+pub type vm_region_basic_info_data_64_t = vm_region_basic_info_64;
+pub type vm_region_basic_info_t = *mut vm_region_basic_info;
+pub type vm_region_basic_info_data_t = vm_region_basic_info;
+pub type vm_region_extended_info_t = *mut vm_region_extended_info;
+pub type vm_region_extended_info_data_t = vm_region_extended_info;
+pub type vm_region_top_info_t = *mut vm_region_top_info;
+pub type vm_region_top_info_data_t = vm_region_top_info;
+pub type vm_region_submap_info_t = *mut vm_region_submap_info;
+pub type vm_region_submap_info_data_t = vm_region_submap_info;
+pub type vm_region_submap_info_64_t = *mut vm_region_submap_info_64;
+pub type vm_region_submap_info_data_64_t = vm_region_submap_info_64;
+pub type vm_region_submap_short_info_64_t = *mut vm_region_submap_short_info_64;
+pub type vm_region_submap_short_info_data_64_t = vm_region_submap_short_info_64;
+pub type vm_page_info_t = *mut ::libc::c_int;
+pub type vm_page_info_flavor_t = ::libc::c_int;
+pub type vm_page_info_basic_t = *mut vm_page_info_basic;
+pub type vm_page_info_basic_data_t = vm_page_info_basic;
+pub type mach_vm_read_entry_t = [mach_vm_read_entry; VM_MAP_ENTRY_MAX as usize];
+
+pub const VM_REGION_INFO_MAX: ::libc::c_int = (1 << 10);
+pub const VM_MAP_ENTRY_MAX: ::libc::c_int = (1 << 8);
+
+pub const VM_PAGE_INFO_BASIC: vm_page_info_flavor_t = 1;
+
+pub const VM_REGION_BASIC_INFO_64: vm_region_flavor_t = 9;
+pub const VM_REGION_BASIC_INFO: vm_region_flavor_t    = 10;
+pub const VM_REGION_EXTENDED_INFO: vm_region_flavor_t = 11;
+pub const VM_REGION_TOP_INFO: vm_region_flavor_t      = 12;
+
+pub const SM_COW: ::libc::c_uchar             = 1;
+pub const SM_PRIVATE: ::libc::c_uchar         = 2;
+pub const SM_EMPTY: ::libc::c_uchar           = 3;
+pub const SM_SHARED: ::libc::c_uchar          = 4;
+pub const SM_TRUESHARED: ::libc::c_uchar      = 5;
+pub const SM_PRIVATE_ALIASED: ::libc::c_uchar = 6;
+pub const SM_SHARED_ALIASED: ::libc::c_uchar  = 7;
+
+#[repr(C)]
+#[derive(Copy, Clone, Debug)]
+pub struct vm_region_basic_info_64 {
+    pub protection: vm_prot_t,
+    pub max_protection: vm_prot_t,
+    pub inheritance: vm_inherit_t,
+    pub shared: boolean_t,
+    pub reserved: boolean_t,
+    pub offset: memory_object_offset_t,
+    pub behavior: vm_behavior_t,
+    pub user_wired_count: ::libc::c_ushort,
+}
+
+impl vm_region_basic_info_64 {
+    pub fn count() -> mach_msg_type_number_t {
+        (mem::size_of::<Self>() / mem::size_of::<::libc::c_int>()) as mach_msg_type_number_t
+    }
+}
+
+#[repr(C)]
+#[derive(Copy, Clone, Debug)]
+pub struct vm_region_basic_info {
+    pub protection: vm_prot_t,
+    pub max_protection: vm_prot_t,
+    pub inheritance: vm_inherit_t,
+    pub shared: boolean_t,
+    pub reserved: boolean_t,
+    pub offset: ::libc::uint32_t,
+    pub behavior: vm_behavior_t,
+    pub user_wired_count: ::libc::c_ushort,
+}
+
+impl vm_region_basic_info {
+    pub fn count() -> mach_msg_type_number_t {
+        (mem::size_of::<Self>() / mem::size_of::<::libc::c_int>()) as mach_msg_type_number_t
+    }
+}
+
+#[repr(C)]
+#[derive(Copy, Clone, Debug)]
+pub struct vm_region_extended_info {
+    pub protection: vm_prot_t,
+    pub user_tag: ::libc::c_uint,
+    pub pages_resident: ::libc::c_uint,
+    pub pages_shared_now_private: ::libc::c_uint,
+    pub pages_swapped_out: ::libc::c_uint,
+    pub pages_dirtied: ::libc::c_uint,
+    pub ref_count: ::libc::c_uint,
+    pub shadow_depth: ::libc::c_ushort,
+    pub external_pager: ::libc::c_uchar,
+    pub share_mode: ::libc::c_uchar,
+}
+
+impl vm_region_extended_info {
+    pub fn count() -> mach_msg_type_number_t {
+        (mem::size_of::<Self>() / mem::size_of::<::libc::c_int>()) as mach_msg_type_number_t
+    }
+}
+
+#[repr(C)]
+#[derive(Copy, Clone, Debug)]
+pub struct vm_region_top_info {
+    pub obj_id: ::libc::c_uint,
+    pub ref_count: ::libc::c_uint,
+    pub private_pages_resident: ::libc::c_uint,
+    pub shared_pages_resident: ::libc::c_uint,
+    pub share_mode: ::libc::c_uchar,
+}
+
+impl vm_region_top_info {
+    pub fn count() -> mach_msg_type_number_t {
+        (mem::size_of::<Self>() / mem::size_of::<::libc::c_int>()) as mach_msg_type_number_t
+    }
+}
+
+#[repr(C)]
+#[derive(Copy, Clone, Debug)]
+pub struct vm_region_submap_info {
+    pub protection: vm_prot_t,
+    pub max_protection: vm_prot_t,
+    pub inheritance: vm_inherit_t,
+    pub offset: ::libc::uint32_t,
+    pub user_tag: ::libc::c_uint,
+    pub pages_resident: ::libc::c_uint,
+    pub pages_shared_now_private: ::libc::c_uint,
+    pub pages_swapped_out: ::libc::c_uint,
+    pub pages_dirtied: ::libc::c_uint,
+    pub ref_count: ::libc::c_uint,
+    pub shadow_depth: ::libc::c_ushort,
+    pub external_pager: ::libc::c_uchar,
+    pub share_mode: ::libc::c_uchar,
+    pub is_submap: boolean_t,
+    pub behavior: vm_behavior_t,
+    pub object_id: vm32_object_id_t,
+    pub user_wired_count: ::libc::c_ushort,
+}
+
+impl vm_region_submap_info {
+    pub fn count() -> mach_msg_type_number_t {
+        (mem::size_of::<Self>() / mem::size_of::<::libc::c_int>()) as mach_msg_type_number_t
+    }
+}
+
+#[repr(C)]
+#[derive(Copy, Clone, Debug)]
+pub struct vm_region_submap_info_64 {
+    pub protection: vm_prot_t,
+    pub max_protection: vm_prot_t,
+    pub inheritance: vm_inherit_t,
+    pub offset: memory_object_offset_t,
+    pub user_tag: ::libc::c_uint,
+    pub pages_resident: ::libc::c_uint,
+    pub pages_shared_now_private: ::libc::c_uint,
+    pub pages_swapped_out: ::libc::c_uint,
+    pub pages_dirtied: ::libc::c_uint,
+    pub ref_count: ::libc::c_uint,
+    pub shadow_depth: ::libc::c_ushort,
+    pub external_pager: ::libc::c_uchar,
+    pub share_mode: ::libc::c_uchar,
+    pub is_submap: boolean_t,
+    pub behavior: vm_behavior_t,
+    pub object_id: vm32_object_id_t,
+    pub user_wired_count: ::libc::c_ushort,
+}
+
+impl vm_region_submap_info_64 {
+    pub fn count() -> mach_msg_type_number_t {
+        (mem::size_of::<Self>() / mem::size_of::<::libc::c_int>()) as mach_msg_type_number_t
+    }
+}
+
+#[repr(C)]
+#[derive(Copy, Clone, Debug)]
+pub struct vm_region_submap_short_info_64 {
+    pub protection: vm_prot_t,
+    pub max_protection: vm_prot_t,
+    pub inheritance: vm_inherit_t,
+    pub offset: memory_object_offset_t,
+    pub user_tag: ::libc::c_uint,
+    pub ref_count: ::libc::c_uint,
+    pub shadow_depth: ::libc::c_ushort,
+    pub external_pager: ::libc::c_uchar,
+    pub share_mode: ::libc::c_uchar,
+    pub is_submap: boolean_t,
+    pub behavior: vm_behavior_t,
+    pub object_id: vm32_object_id_t,
+    pub user_wired_count: ::libc::c_ushort,
+}
+
+impl vm_region_submap_short_info_64 {
+    pub fn count() -> mach_msg_type_number_t {
+        (mem::size_of::<Self>() / mem::size_of::<::libc::c_int>()) as mach_msg_type_number_t
+    }
+}
+
+#[repr(C)]
+#[derive(Copy, Clone, Debug)]
+pub struct vm_page_info_basic {
+    pub disposition: ::libc::c_int,
+    pub ref_count: ::libc::c_int,
+    pub object_id: vm_object_id_t,
+    pub offset: memory_object_offset_t,
+    pub depth: ::libc::c_int,
+    pub __pad: ::libc::c_int,
+}
+
+impl vm_page_info_basic {
+    pub fn count() -> mach_msg_type_number_t {
+        (mem::size_of::<Self>() / mem::size_of::<::libc::c_int>()) as mach_msg_type_number_t
+    }
+}
+
+#[repr(C)]
+#[derive(Copy, Clone, Debug)]
+pub struct mach_vm_read_entry {
+    pub address: mach_vm_address_t,
+    pub size: mach_vm_size_t,
+}
+

--- a/src/vm_sync.rs
+++ b/src/vm_sync.rs
@@ -1,0 +1,11 @@
+//! This module corresponds to `mach/vm_sync.h`.
+
+pub type vm_sync_t = ::libc::c_uint;
+
+pub const VM_SYNC_ASYNCHRONOUS: vm_sync_t  = (1 << 0);
+pub const VM_SYNC_SYNCHRONOUS: vm_sync_t   = (1 << 1);
+pub const VM_SYNC_INVALIDATE: vm_sync_t    = (1 << 2);
+pub const VM_SYNC_KILLPAGES: vm_sync_t     = (1 << 3);
+pub const VM_SYNC_DEACTIVATE: vm_sync_t    = (1 << 4);
+pub const VM_SYNC_CONTIGUOUS: vm_sync_t    = (1 << 5);
+pub const VM_SYNC_REUSABLEPAGES: vm_sync_t = (1 << 6);

--- a/src/vm_types.rs
+++ b/src/vm_types.rs
@@ -1,6 +1,7 @@
 //! This module roughly corresponds to `mach/i386/vm_types.h`.
 
 pub type natural_t = ::libc::c_uint;
+pub type integer_t = ::libc::c_int;
 
 pub type user_addr_t = usize;
 
@@ -10,5 +11,7 @@ pub type mach_vm_size_t    = u64;
 pub type vm_map_offset_t   = u64;
 pub type vm_map_address_t  = u64;
 pub type vm_map_size_t     = u64;
+pub type vm_offset_t       = ::libc::uintptr_t;
+pub type vm_size_t         = ::libc::uintptr_t;
 
 pub type mach_port_context_t = mach_vm_address_t;


### PR DESCRIPTION
These are the definitions for the _mach_vm__\* API. All functions are included except _mach_vm_page_query_ because of the huge dependency chain required by the _vm_map_t_ type.
