### PR TITLE
add missing vm_address_t type

### DIFF
--- a/src/vm_types.rs
+++ b/src/vm_types.rs
@@ -14,5 +14,6 @@ pub type vm_map_size_t     = u64;
 pub type vm_map_t          = ::port::mach_port_t;
 pub type vm_offset_t       = ::libc::uintptr_t;
 pub type vm_size_t         = ::libc::uintptr_t;
+pub type vm_address_t      = vm_offset_t;
 
 pub type mach_port_context_t = mach_vm_address_t;


### PR DESCRIPTION
Adding missing [`vm_address_t`](https://developer.apple.com/documentation/kernel/vm_address_t?language=objc) type