### PR TITLE
Bump minimum rust version to 1.11.0 to fix travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: rust
 rust:
-  - 1.8.0
+  - 1.11.0
   - beta
   - nightly
 os:


### PR DESCRIPTION
Rust 1.[8, 10].0 fails with the same error. Rust 1.11.0 and above (until 1.22.0) seems to work fine.