### PR TITLE
Test relevant XCode versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,48 +3,162 @@ language: rust
 matrix:
   fast_finish: true
   include:
+    # x86_64-apple-darwin
     - env: TARGET=x86_64-apple-darwin
       rust: 1.11.0
       os: osx
+      osx_image: xcode8.3
     - env: TARGET=x86_64-apple-darwin
       rust: beta
       os: osx
+      osx_image: xcode9.2
     - env: TARGET=x86_64-apple-darwin
       rust: nightly
       os: osx
+      osx_image: xcode9.2
+    - env: TARGET=x86_64-apple-darwin
+      rust: nightly
+      os: osx
+      osx_image: xcode8.3
+    - env: TARGET=x86_64-apple-darwin
+      rust: nightly
+      os: osx
+      osx_image: xcode7.3
+    - env: TARGET=x86_64-apple-darwin
+      rust: nightly
+      os: osx
+      osx_image: xcode6.4
+
+    # i686-apple-darwin
     - env: TARGET=i686-apple-darwin
       rust: 1.11.0
       os: osx
+      osx_image: xcode8.3
     - env: TARGET=i686-apple-darwin
       rust: beta
       os: osx
+      osx_image: xcode9.2
     - env: TARGET=i686-apple-darwin
       rust: nightly
       os: osx
-    - env: TARGET=i386-apple-ios
-           CARGO_TARGET_I386_APPLE_IOS_RUNNER=$HOME/runtest
-           RUSTFLAGS=-Clink-arg=-mios-simulator-version-min=7.0
-           NORUN=1
-      rust: nightly      
-      os: osx
-      osx_image: xcode8.2
-      before_install:
-        rustc ./ci/deploy_and_run_on_ios_simulator.rs -o $HOME/runtest
-    - env: TARGET=x86_64-apple-ios
-           CARGO_TARGET_X86_64_APPLE_IOS_RUNNER=$HOME/runtest
-           RUSTFLAGS=-Clink-arg=-mios-simulator-version-min=7.0
-           NORUN=1
+      osx_image: xcode9.2
+    - env: TARGET=i686-apple-darwin
       rust: nightly
       os: osx
-      osx_image: xcode8.2
-      before_install:
-        rustc ./ci/deploy_and_run_on_ios_simulator.rs -o $HOME/runtest
-    - env: TARGET=aarch64-apple-ios NORUN=1
+      osx_image: xcode8.3
+    - env: TARGET=i686-apple-darwin
       rust: nightly
       os: osx
-    - env: TARGET=armv7-apple-ios NORUN=1
+      osx_image: xcode7.3
+    - env: TARGET=i686-apple-darwin
       rust: nightly
       os: osx
+      osx_image: xcode6.4
+
+    # x86_64-apple-ios
+    - env: TARGET=x86_64-apple-ios NORUN=1
+      rust: 1.11.0
+      os: osx
+      osx_image: xcode8.3
+    - env: TARGET=x86_64-apple-ios NORUN=1
+      rust: beta
+      os: osx
+      osx_image: xcode9.2
+    - env: TARGET=x86_64-apple-ios NORUN=1
+      rust: nightly
+      os: osx
+      osx_image: xcode9.2
+    - env: TARGET=x86_64-apple-ios NORUN=1
+      rust: nightly
+      os: osx
+      osx_image: xcode8.3
+    - env: TARGET=x86_64-apple-ios NORUN=1 NOCTEST=1
+      rust: nightly
+      os: osx
+      osx_image: xcode7.3
+    - env: TARGET=x86_64-apple-ios NORUN=1 NOCTEST=1
+      rust: nightly
+      os: osx
+      osx_image: xcode6.4
+
+    # i386-apple-ios
+    - env: TARGET=i386-apple-ios NORUN=1
+      rust: 1.11.0
+      os: osx
+      osx_image: xcode8.3
+    - env: TARGET=i386-apple-ios NORUN=1
+      rust: beta
+      os: osx
+      osx_image: xcode9.2
+    - env: TARGET=i386-apple-ios NORUN=1
+      rust: nightly
+      os: osx
+      osx_image: xcode9.2
+    - env: TARGET=i386-apple-ios NORUN=1
+      rust: nightly
+      os: osx
+      osx_image: xcode8.3
+    - env: TARGET=i386-apple-ios NORUN=1 NOCTEST=1
+      rust: nightly
+      os: osx
+      osx_image: xcode7.3
+    - env: TARGET=i386-apple-ios NORUN=1 NOCTEST=1
+      rust: nightly
+      os: osx
+      osx_image: xcode6.4
+
+    # aarch64-apple-ios
+    - env: TARGET=aarch64-apple-ios NORUN=1 NOCTEST=1
+      rust: 1.11.0
+      os: osx
+      osx_image: xcode8.3
+    - env: TARGET=aarch64-apple-ios NORUN=1 NOCTEST=1
+      rust: beta
+      os: osx
+      osx_image: xcode9.2
+    - env: TARGET=aarch64-apple-ios NORUN=1 NOCTEST=1
+      rust: nightly
+      os: osx
+      osx_image: xcode9.2
+    - env: TARGET=aarch64-apple-ios NORUN=1 NOCTEST=1
+      rust: nightly
+      os: osx
+      osx_image: xcode8.3
+    - env: TARGET=aarch64-apple-ios NORUN=1 NOCTEST=1
+      rust: nightly
+      os: osx
+      osx_image: xcode7.3
+    - env: TARGET=aarch64-apple-ios NORUN=1 NOCTEST=1
+      rust: nightly
+      os: osx
+      osx_image: xcode6.4
+
+    # armv7-apple-ios
+    - env: TARGET=armv7-apple-ios NORUN=1 NOCTEST=1
+      rust: 1.11.0
+      os: osx
+      osx_image: xcode8.3
+    - env: TARGET=armv7-apple-ios NORUN=1 NOCTEST=1
+      rust: beta
+      os: osx
+      osx_image: xcode9.2
+    - env: TARGET=armv7-apple-ios NORUN=1 NOCTEST=1
+      rust: nightly
+      os: osx
+      osx_image: xcode9.2
+    - env: TARGET=armv7-apple-ios NORUN=1 NOCTEST=1
+      rust: nightly
+      os: osx
+      osx_image: xcode8.3
+    - env: TARGET=armv7-apple-ios NORUN=1 NOCTEST=1
+      rust: nightly
+      os: osx
+      osx_image: xcode7.3
+    - env: TARGET=armv7-apple-ios NORUN=1 NOCTEST=1
+      rust: nightly
+      os: osx
+      osx_image: xcode6.4
+
     - env: RUSTFMT
       rust: nightly
       before_script:
@@ -53,27 +167,5 @@ matrix:
         - cargo fmt -- --write-mode=diff
   allow_failures:
     - env: RUSTFMT
-    - env: TARGET=aarch64-apple-ios NORUN=1
-    - env: TARGET=armv7-apple-ios NORUN=1
 script:
-  - rustup target add $TARGET || true
-  - cargo build --target $TARGET --verbose 2>&1 | tee build_std.txt
-  - cargo build --no-default-features --target $TARGET --verbose 2>&1 | tee build_no_std.txt
-
-  # Check that the no-std builds do not include std by accident:
-  - |
-    cat build_std.txt | grep -q "default"
-    cat build_std.txt | grep -q "use_std"
-    ! cat build_no_std.txt | grep -q "default"
-    ! cat build_no_std.txt | grep -q "use_std"
-
-  - |
-    if [[ -z "$NORUN" ]]; then
-        cargo test --target $TARGET
-        cargo test --no-default-features --target $TARGET
-    fi
-  - |
-    if [[ $TRAVIS_RUST_VERSION == "nightly" ]]; then
-        cargo test --manifest-path mach-test/Cargo.toml --target $TARGET
-        cargo test --no-default-features --manifest-path mach-test/Cargo.toml --target $TARGET
-    fi
+  - ci/run.sh

--- a/README.md
+++ b/README.md
@@ -1,3 +1,18 @@
 [![Build Status](https://travis-ci.org/fitzgen/mach.png?branch=master)](https://travis-ci.org/fitzgen/mach)
 
 A rust interface to the Mach 3.0 kernel that underlies OSX.
+
+# Platform support
+
+The following table describes the current CI set-up:
+
+| Target                | Min. Rust |   XCode   | build | ctest | run |
+|-----------------------|-----------|-----------|-------|-------|-----|
+| `x86_64-apple-darwin` |  1.11.0   | 6.4 - 9.2 | ✓     | ✓     | ✓   | 
+| `i686-apple-darwin`   |  1.11.0   | 6.4 - 9.2 | ✓     | ✓     | ✓   |
+| `i386-apple-ios`      |  1.11.0   | 6.4 - 9.2 | ✓     | ✓ [0] | -   |
+| `x86_64-apple-ios`    |  1.11.0   | 6.4 - 9.2 | ✓     | ✓ [0] | -   |
+| `armv7-apple-ios`     |  nightly  | 6.4 - 9.2 | ✓     | -     | -   |
+| `aarch64-apple-ios`   |  nigthly  | 6.4 - 9.2 | ✓     | -     | -   |
+
+[0] `ctest` is only run on iOS for XCode 8.3 version and newer.

--- a/ci/run.sh
+++ b/ci/run.sh
@@ -34,6 +34,8 @@ cat build_std.txt | grep -q "default"
 cat build_std.txt | grep -q "use_std"
 ! cat build_no_std.txt | grep -q "default"
 ! cat build_no_std.txt | grep -q "use_std"
+# Make sure that the resulting build contains no std symbols
+! find target/ -name *.rlib -exec nm {} \; | grep "std"
 
 # Runs mach's run-time tests:
 if [[ -z "$NORUN" ]]; then

--- a/ci/run.sh
+++ b/ci/run.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+
+set -ex
+
+: ${TARGET?"The TARGET environment variable must be set."}
+: ${TRAVIS_RUST_VERSION?"The TRAVIS_RUST_VERSION environment variable must be set."}
+
+echo "Running tests for target: ${TARGET}"
+export RUST_BACKTRACE=1
+export RUST_TEST_THREADS=1
+
+
+if [[ $TARGET == *"ios"* ]]; then
+    export RUSTFLAGS='-C link-args=-mios-simulator-version-min=7.0'
+    rustc ./ci/deploy_and_run_on_ios_simulator.rs -o ios_cargo_runner --verbose
+    if [[ $TARGET == "x86_64-apple-ios" ]]; then
+        export CARGO_TARGET_X86_64_APPLE_IOS_RUNNER=$(pwd)/ios_cargo_runner
+    fi
+    if [[ $TARGET == "i386-apple-ios" ]]; then
+        export CARGO_TARGET_I386_APPLE_IOS_RUNNER=$(pwd)/ios_cargo_runner
+    fi
+fi
+
+rustup target add $TARGET || true
+
+# Build w/o std
+cargo clean
+cargo build --target $TARGET --verbose 2>&1 | tee build_std.txt
+cargo build --no-default-features --target $TARGET --verbose 2>&1 | tee build_no_std.txt
+
+# Check that the no-std builds are not linked against a libc with default
+# features or the use_std feature enabled:
+cat build_std.txt | grep -q "default"
+cat build_std.txt | grep -q "use_std"
+! cat build_no_std.txt | grep -q "default"
+! cat build_no_std.txt | grep -q "use_std"
+
+# Runs mach's run-time tests:
+if [[ -z "$NORUN" ]]; then
+    cargo test --target $TARGET --verbose
+    cargo test --no-default-features --target $TARGET --verbose
+fi
+
+# Runs ctest to verify mach's ABI against the system libraries:
+if [[ -z "$NOCTEST" ]]; then
+    if [[ $TRAVIS_RUST_VERSION == "beta" ]] || [[ $TRAVIS_RUST_VERSION == "nightly" ]]; then
+        cargo test --manifest-path mach-test/Cargo.toml --target $TARGET --verbose
+        cargo test --no-default-features --manifest-path mach-test/Cargo.toml --target $TARGET --verbose
+    fi
+fi


### PR DESCRIPTION
This PR adds test for the most relevant XCode versions ( Closes #26 ) and also tests that `no_std` builds have no symbols ( Closes #24 ).

Subsequent PRs should start fixing ABI issues without breaking anything.