### PR TITLE
Fix undefined-behavior in nightly Rust

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ matrix:
   include:
     # x86_64-apple-darwin
     - env: TARGET=x86_64-apple-darwin
-      rust: 1.11.0
+      rust: 1.13.0
       os: osx
       osx_image: xcode8.3
     - env: TARGET=x86_64-apple-darwin
@@ -31,7 +31,7 @@ matrix:
 
     # i686-apple-darwin
     - env: TARGET=i686-apple-darwin
-      rust: 1.11.0
+      rust: 1.13.0
       os: osx
       osx_image: xcode8.3
     - env: TARGET=i686-apple-darwin
@@ -57,7 +57,7 @@ matrix:
 
     # x86_64-apple-ios
     - env: TARGET=x86_64-apple-ios NORUN=1
-      rust: 1.11.0
+      rust: 1.13.0
       os: osx
       osx_image: xcode8.3
     - env: TARGET=x86_64-apple-ios NORUN=1
@@ -83,7 +83,7 @@ matrix:
 
     # i386-apple-ios
     - env: TARGET=i386-apple-ios NORUN=1
-      rust: 1.11.0
+      rust: 1.13.0
       os: osx
       osx_image: xcode8.3
     - env: TARGET=i386-apple-ios NORUN=1
@@ -109,7 +109,7 @@ matrix:
 
     # aarch64-apple-ios
     - env: TARGET=aarch64-apple-ios NORUN=1 NOCTEST=1
-      rust: 1.11.0
+      rust: 1.13.0
       os: osx
       osx_image: xcode8.3
     - env: TARGET=aarch64-apple-ios NORUN=1 NOCTEST=1
@@ -135,7 +135,7 @@ matrix:
 
     # armv7-apple-ios
     - env: TARGET=armv7-apple-ios NORUN=1 NOCTEST=1
-      rust: 1.11.0
+      rust: 1.13.0
       os: osx
       osx_image: xcode8.3
     - env: TARGET=armv7-apple-ios NORUN=1 NOCTEST=1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,5 +18,7 @@ default-features = false
 [features]
 default = [ "use_std", "deprecated" ]
 use_std = [ "libc/use_std" ]
+# Enables unstable / nightly-only features
+unstable = []
 # Enables deprecated and removed APIs.
 deprecated = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "mach"
-version = "0.1.2"
+version = "0.2.0"
 authors = ["Nick Fitzgerald <fitzgen@gmail.com>", "David Cuddeback <david.cuddeback@gmail.com>"]
 
 license = "BSD-2-Clause"

--- a/ci/run.sh
+++ b/ci/run.sh
@@ -45,7 +45,7 @@ fi
 
 # Runs ctest to verify mach's ABI against the system libraries:
 if [[ -z "$NOCTEST" ]]; then
-    if [[ $TRAVIS_RUST_VERSION == "beta" ]] || [[ $TRAVIS_RUST_VERSION == "nightly" ]]; then
+    if [[ $TRAVIS_RUST_VERSION == "nightly" ]]; then
         cargo test --manifest-path mach-test/Cargo.toml --target $TARGET --verbose
         cargo test --no-default-features --manifest-path mach-test/Cargo.toml --target $TARGET --verbose
     fi

--- a/mach-test/Cargo.toml
+++ b/mach-test/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["gnzlbg <gonzalobg88@gmail.com>"]
 build = "build.rs"
 
 [dependencies]
-mach = { path = ".." }
+mach = { path = "..", features = ["unstable"] }
 libc = "0.2"
 
 [build-dependencies]

--- a/mach-test/build.rs
+++ b/mach-test/build.rs
@@ -141,15 +141,7 @@ fn main() {
             // FIXME: this type is not exposed in /usr/include/mach
             // but seems to be exposed in
             // SDKs/MacOSX.sdk/System/Library/Frameworks/Kernel.framework/Versions/A/Headers/mach
-            "ipc_port" |
-
-            // FIXME: should use repr(packed(4))
-            "task_dyld_info" |
-            "vm_region_basic_info_64" |
-            "vm_region_submap_info_64" |
-            "vm_region_submap_short_info_64" |
-            "mach_vm_read_entry"
-                => true,
+            "ipc_port" => true,
 
             // These are not available in previous MacOSX versions:
             "dyld_kernel_image_info" |
@@ -166,14 +158,7 @@ fn main() {
             // FIXME: this type is not exposed in /usr/include/mach
             // but seems to be exposed in
             // SDKs/MacOSX.sdk/System/Library/Frameworks/Kernel.framework/Versions/A/Headers/mach
-            "ipc_port_t" |
-
-            // FIXME: corresponding struct should use repr(packed(4))
-            "vm_region_basic_info_data_64_t" |
-            "vm_region_submap_info_data_64_t"|
-            "vm_region_submap_short_info_data_64_t" |
-            "mach_vm_read_entry_t"
-                => true,
+            "ipc_port_t" => true,
 
             // These are not available in previous MacOSX versions
             "dyld_kernel_image_info_t" |

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,8 @@
-#![feature(repr_packed)]
 #![allow(non_camel_case_types)]
 #![allow(non_upper_case_globals)]
 
 #![cfg_attr(not(feature = "use_std"), no_std)]
+#![cfg_attr(feature = "unstable", feature(repr_packed))]
 
 #[cfg(feature = "use_std")]
 extern crate core;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+#![feature(repr_packed)]
 #![allow(non_camel_case_types)]
 #![allow(non_upper_case_globals)]
 

--- a/src/task_info.rs
+++ b/src/task_info.rs
@@ -34,7 +34,8 @@ pub const TASK_DEBUG_INFO_INTERNAL: ::libc::c_uint = 29;
 pub type task_flavor_t = natural_t;
 pub type task_info_t = *mut integer_t;
 
-#[repr(C, packed(4))]
+#[repr(C)]
+#[cfg_attr(feature = "unstable", repr(packed(4)))]
 pub struct task_dyld_info {
     pub all_image_info_addr: mach_vm_address_t,
     pub all_image_info_size: mach_vm_size_t,

--- a/src/task_info.rs
+++ b/src/task_info.rs
@@ -34,9 +34,7 @@ pub const TASK_DEBUG_INFO_INTERNAL: ::libc::c_uint = 29;
 pub type task_flavor_t = natural_t;
 pub type task_info_t = *mut integer_t;
 
-#[repr(C)]
-// Undefined behavior: should be #[repr(packed(4))] once
-// that is stable: https://github.com/rust-lang/rust/issues/33158
+#[repr(C, packed(4))]
 pub struct task_dyld_info {
     pub all_image_info_addr: mach_vm_address_t,
     pub all_image_info_size: mach_vm_size_t,

--- a/src/vm_region.rs
+++ b/src/vm_region.rs
@@ -56,10 +56,8 @@ pub const SM_TRUESHARED: ::libc::c_uchar      = 5;
 pub const SM_PRIVATE_ALIASED: ::libc::c_uchar = 6;
 pub const SM_SHARED_ALIASED: ::libc::c_uchar  = 7;
 
-#[repr(C)]
+#[repr(C, packed(4))]
 #[derive(Copy, Clone, Debug)]
-// Undefined behavior: should be #[repr(packed(4))] once
-// that is stable: https://github.com/rust-lang/rust/issues/33158
 pub struct vm_region_basic_info_64 {
     pub protection: vm_prot_t,
     pub max_protection: vm_prot_t,
@@ -162,10 +160,8 @@ impl vm_region_submap_info {
     }
 }
 
-#[repr(C)]
+#[repr(C, packed(4))]
 #[derive(Copy, Clone, Debug)]
-// Undefined behavior: should be #[repr(packed(4))] once
-// that is stable: https://github.com/rust-lang/rust/issues/33158
 pub struct vm_region_submap_info_64 {
     pub protection: vm_prot_t,
     pub max_protection: vm_prot_t,
@@ -193,10 +189,8 @@ impl vm_region_submap_info_64 {
     }
 }
 
-#[repr(C)]
+#[repr(C, packed(4))]
 #[derive(Copy, Clone, Debug)]
-// Undefined behavior: should be #[repr(packed(4))] once
-// that is stable: https://github.com/rust-lang/rust/issues/33158
 pub struct vm_region_submap_short_info_64 {
     pub protection: vm_prot_t,
     pub max_protection: vm_prot_t,
@@ -236,10 +230,8 @@ impl vm_page_info_basic {
     }
 }
 
-#[repr(C)]
+#[repr(C, packed(4))]
 #[derive(Copy, Clone, Debug)]
-// Undefined behavior: should be #[repr(packed(4))] once
-// that is stable: https://github.com/rust-lang/rust/issues/33158
 pub struct mach_vm_read_entry {
     pub address: mach_vm_address_t,
     pub size: mach_vm_size_t,

--- a/src/vm_region.rs
+++ b/src/vm_region.rs
@@ -56,7 +56,8 @@ pub const SM_TRUESHARED: ::libc::c_uchar      = 5;
 pub const SM_PRIVATE_ALIASED: ::libc::c_uchar = 6;
 pub const SM_SHARED_ALIASED: ::libc::c_uchar  = 7;
 
-#[repr(C, packed(4))]
+#[repr(C)]
+#[cfg_attr(feature = "unstable", repr(packed(4)))]
 #[derive(Copy, Clone, Debug)]
 pub struct vm_region_basic_info_64 {
     pub protection: vm_prot_t,
@@ -160,7 +161,8 @@ impl vm_region_submap_info {
     }
 }
 
-#[repr(C, packed(4))]
+#[repr(C)]
+#[cfg_attr(feature = "unstable", repr(packed(4)))]
 #[derive(Copy, Clone, Debug)]
 pub struct vm_region_submap_info_64 {
     pub protection: vm_prot_t,
@@ -189,7 +191,8 @@ impl vm_region_submap_info_64 {
     }
 }
 
-#[repr(C, packed(4))]
+#[repr(C)]
+#[cfg_attr(feature = "unstable", repr(packed(4)))]
 #[derive(Copy, Clone, Debug)]
 pub struct vm_region_submap_short_info_64 {
     pub protection: vm_prot_t,
@@ -230,7 +233,8 @@ impl vm_page_info_basic {
     }
 }
 
-#[repr(C, packed(4))]
+#[repr(C)]
+#[cfg_attr(feature = "unstable", repr(packed(4)))]
 #[derive(Copy, Clone, Debug)]
 pub struct mach_vm_read_entry {
     pub address: mach_vm_address_t,


### PR DESCRIPTION
MacOSX uses `#pragma pack 4` to pack all of its structs on `x86_64` but `mach` did not.

This resulted in the Rust structs of `mach` having a different layout than the C `structs` which is undefined behavior. 

This PR fixes this using `repr(packed)` for nightly Rust builds. It adds a new opt-in feature to the crate called `unstable` that enables the `repr_packed` feature  and it conditionally applies `repr(packed(N))` to all structs with incorrect layout.

---

Note: the stable Rust build bots currently fail because Rust 1.11.0 is too old: it does not have attribute literals. I've made a similar PR to libc where the exact same thing happened. I'll wait till that is merged and will bump our stable Rust version to continue to match that of libc: https://github.com/rust-lang/libc/pull/972