### PR TITLE
fix ctest version to 0.2.0

### DIFF
--- a/mach-test/Cargo.toml
+++ b/mach-test/Cargo.toml
@@ -9,7 +9,7 @@ mach = { path = "..", features = ["unstable"] }
 libc = "0.2"
 
 [build-dependencies]
-ctest = { git = "https://github.com/alexcrichton/ctest" }
+ctest = "= 0.2.0"
 
 [[test]]
 name = "main"


### PR DESCRIPTION
It appears that `ctest` made a backwards incompatible change at some point. I'll try to fix that, but in the mean time, this should do the trick.