### PR TITLE
Deprecate unsound APIs

### DIFF
--- a/src/clock_types.rs
+++ b/src/clock_types.rs
@@ -7,8 +7,8 @@ pub type clock_flavor_t = ::libc::c_int;
 pub type clock_attr_t = *mut ::libc::c_int;
 pub type clock_res_t = ::libc::c_int;
 
-#[derive(Copy, Clone, PartialEq, PartialOrd, Eq, Ord, Debug, Hash)]
 #[repr(C)]
+#[derive(Copy, Clone, Debug, Default, Hash, PartialOrd, PartialEq, Eq, Ord)]
 pub struct mach_timespec {
     pub tv_sec: ::libc::c_uint,
     pub tv_nsec: clock_res_t,

--- a/src/dyld_kernel.rs
+++ b/src/dyld_kernel.rs
@@ -4,7 +4,7 @@ use boolean::boolean_t;
 use mach_types::{fsid_t, fsobj_id_t, uuid_t};
 
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone, Hash, PartialOrd, PartialEq)]
+#[derive(Copy, Clone, Debug, Default, Hash, PartialOrd, PartialEq, Eq, Ord)]
 pub struct dyld_kernel_image_info {
     pub uuid: uuid_t,
     pub fsobjid: fsobj_id_t,
@@ -14,7 +14,7 @@ pub struct dyld_kernel_image_info {
 
 #[allow(non_snake_case)]
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone, Hash, PartialOrd, PartialEq)]
+#[derive(Copy, Clone, Debug, Default, Hash, PartialOrd, PartialEq, Eq, Ord)]
 pub struct dyld_kernel_process_info {
     pub cache_image_info: dyld_kernel_image_info,
     pub timestamp: u64,

--- a/src/mach_types.rs
+++ b/src/mach_types.rs
@@ -90,7 +90,7 @@ pub type uuid_t = [::libc::c_uchar; 16];
 
 // <sys/_types/_fsid_t.h>
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone, Hash, PartialOrd, PartialEq)]
+#[derive(Copy, Clone, Debug, Default, Hash, PartialOrd, PartialEq, Eq, Ord)]
 pub struct fsid {
     pub val: [i32; 2],
 }
@@ -98,7 +98,7 @@ pub type fsid_t = fsid;
 
 // <sys/_types/_fsobj_id_t.h>
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone, Hash, PartialOrd, PartialEq)]
+#[derive(Copy, Clone, Debug, Default, Hash, PartialOrd, PartialEq, Eq, Ord)]
 pub struct fsobj_id {
     pub fid_objno: u32,
     pub fid_generation: u32,

--- a/src/message.rs
+++ b/src/message.rs
@@ -131,7 +131,7 @@ pub const MACH_RCV_INVALID_TRAILER: mach_msg_return_t = 0x1000_400f;
 pub const MACH_RCV_IN_PROGRESS_TIMED: mach_msg_return_t = 0x1000_4011;
 
 #[repr(C)]
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, Default, Hash, PartialOrd, PartialEq, Eq, Ord)]
 pub struct mach_msg_header_t {
     pub msgh_bits: mach_msg_bits_t,
     pub msgh_size: mach_msg_size_t,
@@ -142,13 +142,13 @@ pub struct mach_msg_header_t {
 }
 
 #[repr(C)]
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, Default, Hash, PartialOrd, PartialEq, Eq, Ord)]
 pub struct mach_msg_body_t {
     pub msgh_descriptor_count: mach_msg_size_t,
 }
 
 #[repr(C)]
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, Default, Hash, PartialOrd, PartialEq, Eq, Ord)]
 pub struct mach_msg_base_t {
     pub header: mach_msg_header_t,
     pub body: mach_msg_body_t,
@@ -157,14 +157,14 @@ pub struct mach_msg_base_t {
 pub const MACH_MSG_TRAILER_FORMAT_0: mach_msg_trailer_type_t = 0;
 
 #[repr(C)]
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, Default, Hash, PartialOrd, PartialEq, Eq, Ord)]
 pub struct mach_msg_trailer_t {
     pub msgh_trailer_type: mach_msg_trailer_type_t,
     pub msgh_trailer_size: mach_msg_trailer_size_t,
 }
 
 #[repr(C)]
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, Default, Hash, PartialOrd, PartialEq, Eq, Ord)]
 pub struct mach_msg_port_descriptor_t {
     pub name: mach_port_t,
     pub pad1: mach_msg_size_t,
@@ -186,7 +186,7 @@ impl mach_msg_port_descriptor_t {
 }
 
 #[repr(C)]
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, Hash, PartialOrd, PartialEq, Eq, Ord)]
 pub struct mach_msg_ool_descriptor_t {
     pub address: *mut ::libc::c_void,
     #[cfg(not(target_pointer_width = "64"))]
@@ -218,7 +218,7 @@ impl mach_msg_ool_descriptor_t {
 }
 
 #[repr(C)]
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, Hash, PartialOrd, PartialEq, Eq, Ord)]
 pub struct mach_msg_ool_ports_descriptor_t {
     pub address: *mut ::libc::c_void,
     #[cfg(not(target_pointer_width = "64"))]

--- a/src/port.rs
+++ b/src/port.rs
@@ -5,6 +5,7 @@ use vm_types::natural_t;
 pub type mach_port_name_t = natural_t;
 
 #[repr(C)]
+#[derive(Copy, Clone, Debug, Default, Hash, PartialOrd, PartialEq, Eq, Ord)]
 pub struct ipc_port;
 
 pub type ipc_port_t = *mut ipc_port;

--- a/src/structs.rs
+++ b/src/structs.rs
@@ -5,7 +5,7 @@ use core::mem;
 use message::mach_msg_type_number_t;
 
 #[repr(C)]
-#[derive(Clone, Debug, Default)]
+#[derive(Copy, Clone, Debug, Default, Hash, PartialOrd, PartialEq, Eq, Ord)]
 pub struct x86_thread_state64_t {
     pub __rax: u64,
     pub __rbx: u64,

--- a/src/task_info.rs
+++ b/src/task_info.rs
@@ -43,6 +43,7 @@ pub type task_info_t = *mut integer_t;
         note = "requires the unstable feature to avoid undefined behavior"
     )
 )]
+#[cfg_attr(not(feature = "unstable"), allow(deprecated))]
 #[derive(Copy, Clone, Debug, Default, Hash, PartialOrd, PartialEq, Eq, Ord)]
 pub struct task_dyld_info {
     pub all_image_info_addr: mach_vm_address_t,

--- a/src/task_info.rs
+++ b/src/task_info.rs
@@ -36,6 +36,13 @@ pub type task_info_t = *mut integer_t;
 
 #[repr(C)]
 #[cfg_attr(feature = "unstable", repr(packed(4)))]
+#[cfg_attr(
+    not(feature = "unstable"),
+    deprecated(
+        since = "0.2.3",
+        note = "requires the unstable feature to avoid undefined behavior"
+    )
+)]
 pub struct task_dyld_info {
     pub all_image_info_addr: mach_vm_address_t,
     pub all_image_info_size: mach_vm_size_t,

--- a/src/task_info.rs
+++ b/src/task_info.rs
@@ -43,6 +43,7 @@ pub type task_info_t = *mut integer_t;
         note = "requires the unstable feature to avoid undefined behavior"
     )
 )]
+#[derive(Copy, Clone, Debug, Default, Hash, PartialOrd, PartialEq, Eq, Ord)]
 pub struct task_dyld_info {
     pub all_image_info_addr: mach_vm_address_t,
     pub all_image_info_size: mach_vm_size_t,

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -11,9 +11,11 @@ use vm_behavior::vm_behavior_t;
 use vm_inherit::vm_inherit_t;
 use vm_prot::vm_prot_t;
 use vm_purgable::vm_purgable_t;
-use vm_region::*;
 use vm_sync::vm_sync_t;
 use vm_types::*;
+
+#[cfg_attr(not(feature = "unstable"), allow(deprecated))]
+use vm_region::*;
 
 extern "C" {
     pub fn mach_vm_allocate(
@@ -52,6 +54,14 @@ extern "C" {
         dataCnt: *mut mach_msg_type_number_t,
     ) -> kern_return_t;
 
+    #[cfg_attr(
+        not(feature = "unstable"),
+        deprecated(
+            since = "0.2.3",
+            note = "requires the `unstable` feature to avoid undefined behavior"
+        )
+    )]
+    #[cfg_attr(not(feature = "unstable"), allow(deprecated))]
     pub fn mach_vm_read_list(
         target_task: vm_task_entry_t,
         data_list: mach_vm_read_entry_t,
@@ -216,6 +226,7 @@ mod tests {
         }
     }
 
+    #[cfg_attr(not(feature = "unstable"), allow(deprecated))]
     #[test]
     fn mach_vm_region_sanity() {
         unsafe {

--- a/src/vm_region.rs
+++ b/src/vm_region.rs
@@ -58,6 +58,13 @@ pub const SM_SHARED_ALIASED: ::libc::c_uchar = 7;
 
 #[repr(C)]
 #[cfg_attr(feature = "unstable", repr(packed(4)))]
+#[cfg_attr(
+    not(feature = "unstable"),
+    deprecated(
+        since = "0.2.3",
+        note = "requires the unstable feature to avoid undefined behavior"
+    )
+)]
 #[derive(Copy, Clone, Debug)]
 pub struct vm_region_basic_info_64 {
     pub protection: vm_prot_t,
@@ -163,6 +170,13 @@ impl vm_region_submap_info {
 
 #[repr(C)]
 #[cfg_attr(feature = "unstable", repr(packed(4)))]
+#[cfg_attr(
+    not(feature = "unstable"),
+    deprecated(
+        since = "0.2.3",
+        note = "requires the `unstable` feature to avoid undefined behavior"
+    )
+)]
 #[derive(Copy, Clone, Debug)]
 pub struct vm_region_submap_info_64 {
     pub protection: vm_prot_t,
@@ -193,6 +207,13 @@ impl vm_region_submap_info_64 {
 
 #[repr(C)]
 #[cfg_attr(feature = "unstable", repr(packed(4)))]
+#[cfg_attr(
+    not(feature = "unstable"),
+    deprecated(
+        since = "0.2.3",
+        note = "requires the `unstable` feature to avoid undefined behavior"
+    )
+)]
 #[derive(Copy, Clone, Debug)]
 pub struct vm_region_submap_short_info_64 {
     pub protection: vm_prot_t,
@@ -235,6 +256,13 @@ impl vm_page_info_basic {
 
 #[repr(C)]
 #[cfg_attr(feature = "unstable", repr(packed(4)))]
+#[cfg_attr(
+    not(feature = "unstable"),
+    deprecated(
+        since = "0.2.3",
+        note = "requires the `unstable` feature to avoid undefined behavior"
+    )
+)]
 #[derive(Copy, Clone, Debug)]
 pub struct mach_vm_read_entry {
     pub address: mach_vm_address_t,

--- a/src/vm_region.rs
+++ b/src/vm_region.rs
@@ -18,7 +18,23 @@ pub type vm_region_recurse_info_t = *mut ::libc::c_int;
 pub type vm_region_recurse_info_64_t = *mut ::libc::c_int;
 pub type vm_region_flavor_t = ::libc::c_int;
 pub type vm_region_info_data_t = [::libc::c_int; VM_REGION_INFO_MAX as usize];
+#[cfg_attr(
+    not(feature = "unstable"),
+    deprecated(
+        since = "0.2.3",
+        note = "requires the `unstable` feature to avoid undefined behavior"
+    )
+)]
+#[cfg_attr(not(feature = "unstable"), allow(deprecated))]
 pub type vm_region_basic_info_64_t = *mut vm_region_basic_info_64;
+#[cfg_attr(
+    not(feature = "unstable"),
+    deprecated(
+        since = "0.2.3",
+        note = "requires the `unstable` feature to avoid undefined behavior"
+    )
+)]
+#[cfg_attr(not(feature = "unstable"), allow(deprecated))]
 pub type vm_region_basic_info_data_64_t = vm_region_basic_info_64;
 pub type vm_region_basic_info_t = *mut vm_region_basic_info;
 pub type vm_region_basic_info_data_t = vm_region_basic_info;
@@ -28,14 +44,54 @@ pub type vm_region_top_info_t = *mut vm_region_top_info;
 pub type vm_region_top_info_data_t = vm_region_top_info;
 pub type vm_region_submap_info_t = *mut vm_region_submap_info;
 pub type vm_region_submap_info_data_t = vm_region_submap_info;
+#[cfg_attr(
+    not(feature = "unstable"),
+    deprecated(
+        since = "0.2.3",
+        note = "requires the `unstable` feature to avoid undefined behavior"
+    )
+)]
+#[cfg_attr(not(feature = "unstable"), allow(deprecated))]
 pub type vm_region_submap_info_64_t = *mut vm_region_submap_info_64;
+#[cfg_attr(
+    not(feature = "unstable"),
+    deprecated(
+        since = "0.2.3",
+        note = "requires the `unstable` feature to avoid undefined behavior"
+    )
+)]
+#[cfg_attr(not(feature = "unstable"), allow(deprecated))]
 pub type vm_region_submap_info_data_64_t = vm_region_submap_info_64;
+#[cfg_attr(
+    not(feature = "unstable"),
+    deprecated(
+        since = "0.2.3",
+        note = "requires the `unstable` feature to avoid undefined behavior"
+    )
+)]
+#[cfg_attr(not(feature = "unstable"), allow(deprecated))]
 pub type vm_region_submap_short_info_64_t = *mut vm_region_submap_short_info_64;
+#[cfg_attr(
+    not(feature = "unstable"),
+    deprecated(
+        since = "0.2.3",
+        note = "requires the `unstable` feature to avoid undefined behavior"
+    )
+)]
+#[cfg_attr(not(feature = "unstable"), allow(deprecated))]
 pub type vm_region_submap_short_info_data_64_t = vm_region_submap_short_info_64;
 pub type vm_page_info_t = *mut ::libc::c_int;
 pub type vm_page_info_flavor_t = ::libc::c_int;
 pub type vm_page_info_basic_t = *mut vm_page_info_basic;
 pub type vm_page_info_basic_data_t = vm_page_info_basic;
+#[cfg_attr(
+    not(feature = "unstable"),
+    deprecated(
+        since = "0.2.3",
+        note = "requires the `unstable` feature to avoid undefined behavior"
+    )
+)]
+#[cfg_attr(not(feature = "unstable"), allow(deprecated))]
 pub type mach_vm_read_entry_t = [mach_vm_read_entry; VM_MAP_ENTRY_MAX as usize];
 
 pub const VM_REGION_INFO_MAX: ::libc::c_int = (1 << 10);
@@ -65,6 +121,7 @@ pub const SM_SHARED_ALIASED: ::libc::c_uchar = 7;
         note = "requires the unstable feature to avoid undefined behavior"
     )
 )]
+#[cfg_attr(not(feature = "unstable"), allow(deprecated))]
 #[derive(Copy, Clone, Debug, Default, Hash, PartialOrd, PartialEq, Eq, Ord)]
 pub struct vm_region_basic_info_64 {
     pub protection: vm_prot_t,
@@ -77,6 +134,14 @@ pub struct vm_region_basic_info_64 {
     pub user_wired_count: ::libc::c_ushort,
 }
 
+#[cfg_attr(
+    not(feature = "unstable"),
+    deprecated(
+        since = "0.2.3",
+        note = "requires the `unstable` feature to avoid undefined behavior"
+    )
+)]
+#[cfg_attr(not(feature = "unstable"), allow(deprecated))]
 impl vm_region_basic_info_64 {
     pub fn count() -> mach_msg_type_number_t {
         (mem::size_of::<Self>() / mem::size_of::<::libc::c_int>()) as mach_msg_type_number_t
@@ -177,6 +242,7 @@ impl vm_region_submap_info {
         note = "requires the `unstable` feature to avoid undefined behavior"
     )
 )]
+#[cfg_attr(not(feature = "unstable"), allow(deprecated))]
 #[derive(Copy, Clone, Debug, Default, Hash, PartialOrd, PartialEq, Eq, Ord)]
 pub struct vm_region_submap_info_64 {
     pub protection: vm_prot_t,
@@ -199,6 +265,14 @@ pub struct vm_region_submap_info_64 {
     pub pages_reusable: ::libc::c_uint,
 }
 
+#[cfg_attr(
+    not(feature = "unstable"),
+    deprecated(
+        since = "0.2.3",
+        note = "requires the `unstable` feature to avoid undefined behavior"
+    )
+)]
+#[cfg_attr(not(feature = "unstable"), allow(deprecated))]
 impl vm_region_submap_info_64 {
     pub fn count() -> mach_msg_type_number_t {
         (mem::size_of::<Self>() / mem::size_of::<::libc::c_int>()) as mach_msg_type_number_t
@@ -214,6 +288,7 @@ impl vm_region_submap_info_64 {
         note = "requires the `unstable` feature to avoid undefined behavior"
     )
 )]
+#[cfg_attr(not(feature = "unstable"), allow(deprecated))]
 #[derive(Copy, Clone, Debug, Default, Hash, PartialOrd, PartialEq, Eq, Ord)]
 pub struct vm_region_submap_short_info_64 {
     pub protection: vm_prot_t,
@@ -231,6 +306,14 @@ pub struct vm_region_submap_short_info_64 {
     pub user_wired_count: ::libc::c_ushort,
 }
 
+#[cfg_attr(
+    not(feature = "unstable"),
+    deprecated(
+        since = "0.2.3",
+        note = "requires the `unstable` feature to avoid undefined behavior"
+    )
+)]
+#[cfg_attr(not(feature = "unstable"), allow(deprecated))]
 impl vm_region_submap_short_info_64 {
     pub fn count() -> mach_msg_type_number_t {
         (mem::size_of::<Self>() / mem::size_of::<::libc::c_int>()) as mach_msg_type_number_t
@@ -263,6 +346,7 @@ impl vm_page_info_basic {
         note = "requires the `unstable` feature to avoid undefined behavior"
     )
 )]
+#[cfg_attr(not(feature = "unstable"), allow(deprecated))]
 #[derive(Copy, Clone, Debug, Default, Hash, PartialOrd, PartialEq, Eq, Ord)]
 pub struct mach_vm_read_entry {
     pub address: mach_vm_address_t,

--- a/src/vm_region.rs
+++ b/src/vm_region.rs
@@ -65,7 +65,7 @@ pub const SM_SHARED_ALIASED: ::libc::c_uchar = 7;
         note = "requires the unstable feature to avoid undefined behavior"
     )
 )]
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, Default, Hash, PartialOrd, PartialEq, Eq, Ord)]
 pub struct vm_region_basic_info_64 {
     pub protection: vm_prot_t,
     pub max_protection: vm_prot_t,
@@ -84,7 +84,7 @@ impl vm_region_basic_info_64 {
 }
 
 #[repr(C)]
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, Default, Hash, PartialOrd, PartialEq, Eq, Ord)]
 pub struct vm_region_basic_info {
     pub protection: vm_prot_t,
     pub max_protection: vm_prot_t,
@@ -103,7 +103,7 @@ impl vm_region_basic_info {
 }
 
 #[repr(C)]
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, Default, Hash, PartialOrd, PartialEq, Eq, Ord)]
 pub struct vm_region_extended_info {
     pub protection: vm_prot_t,
     pub user_tag: ::libc::c_uint,
@@ -125,7 +125,7 @@ impl vm_region_extended_info {
 }
 
 #[repr(C)]
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, Default, Hash, PartialOrd, PartialEq, Eq, Ord)]
 pub struct vm_region_top_info {
     pub obj_id: ::libc::c_uint,
     pub ref_count: ::libc::c_uint,
@@ -141,7 +141,7 @@ impl vm_region_top_info {
 }
 
 #[repr(C)]
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, Default, Hash, PartialOrd, PartialEq, Eq, Ord)]
 pub struct vm_region_submap_info {
     pub protection: vm_prot_t,
     pub max_protection: vm_prot_t,
@@ -177,7 +177,7 @@ impl vm_region_submap_info {
         note = "requires the `unstable` feature to avoid undefined behavior"
     )
 )]
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, Default, Hash, PartialOrd, PartialEq, Eq, Ord)]
 pub struct vm_region_submap_info_64 {
     pub protection: vm_prot_t,
     pub max_protection: vm_prot_t,
@@ -214,7 +214,7 @@ impl vm_region_submap_info_64 {
         note = "requires the `unstable` feature to avoid undefined behavior"
     )
 )]
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, Default, Hash, PartialOrd, PartialEq, Eq, Ord)]
 pub struct vm_region_submap_short_info_64 {
     pub protection: vm_prot_t,
     pub max_protection: vm_prot_t,
@@ -238,7 +238,7 @@ impl vm_region_submap_short_info_64 {
 }
 
 #[repr(C)]
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, Default, Hash, PartialOrd, PartialEq, Eq, Ord)]
 pub struct vm_page_info_basic {
     pub disposition: ::libc::c_int,
     pub ref_count: ::libc::c_int,
@@ -263,7 +263,7 @@ impl vm_page_info_basic {
         note = "requires the `unstable` feature to avoid undefined behavior"
     )
 )]
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, Default, Hash, PartialOrd, PartialEq, Eq, Ord)]
 pub struct mach_vm_read_entry {
     pub address: mach_vm_address_t,
     pub size: mach_vm_size_t,

--- a/src/vm_statistics.rs
+++ b/src/vm_statistics.rs
@@ -45,6 +45,7 @@ pub const VM_FLAGS_ANYWHERE: ::libc::c_int = 0x1;
 pub const VM_FLAGS_OVERWRITE: ::libc::c_int = 0x4000;
 
 #[repr(C)]
+#[derive(Copy, Clone, Debug, Default, Hash, PartialOrd, PartialEq, Eq, Ord)]
 pub struct vm_statistics {
     pub free_count: natural_t,
     pub active_count: natural_t,
@@ -69,6 +70,7 @@ pub struct vm_statistics {
     note = "`pmap_statistics` was removed after MacOSX 10.3.9"
 )]
 #[repr(C)]
+#[derive(Copy, Clone, Debug, Default, Hash, PartialOrd, PartialEq, Eq, Ord)]
 pub struct pmap_statistics {
     pub resident_count: integer_t,
     pub wired_count: integer_t,

--- a/src/vm_statistics.rs
+++ b/src/vm_statistics.rs
@@ -69,6 +69,7 @@ pub struct vm_statistics {
     since = "0.2.3",
     note = "`pmap_statistics` was removed after MacOSX 10.3.9"
 )]
+#[cfg_attr(feature = "deprecated", allow(deprecated))]
 #[repr(C)]
 #[derive(Copy, Clone, Debug, Default, Hash, PartialOrd, PartialEq, Eq, Ord)]
 pub struct pmap_statistics {


### PR DESCRIPTION
This PR deprecates unsound APIs, raising a warning in (and thus informing) those projects that are depending on them. These APIs won't be removed, but they will remain deprecated until they can be used safely. Projects that depend on them can either use the `unstable` feature, use `rust-bindgen` for these, or just silence the warning after being properly informed that doing so introduces undefined behavior.