### PR TITLE
Fix xcode64 builds

### DIFF
--- a/mach-test/build.rs
+++ b/mach-test/build.rs
@@ -86,8 +86,9 @@ fn main() {
         .header("mach/mach_voucher_types.h")
         .header("mach/machine.h")
         .header("mach/memory_object_types.h")
-        .header("mach/message.h")
-        .header("mach/ndr.h")
+        .header("mach/message.h");
+
+    cfg.header("mach/ndr.h")
         .header("mach/notify.h")
         .header("mach/policy.h")
         .header("mach/port.h")


### PR DESCRIPTION
cc @alexcrichton This `build.rs` used to work, but at some point, the `build.rs` started having a stack overflow in the build bots that use `xcode 6.4`. I think this is a rustc regression bug on macosx, and not a `ctest` issue, but I don't have an OSX system with xcode 6.4 available, and while one can reproduce this consistently in travis, debugging it there is a real pain.