### PR TITLE
disable ffi and run tests for the ios simulator targets

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -78,28 +78,28 @@ matrix:
       osx_image: xcode6.4
 
     # x86_64-apple-ios
-    - name: "x86_64-apple-ios - Rust stable 1.18.0 - xcode10 - no run tests"
-      env: TARGET=x86_64-apple-ios NORUN=1
+    - name: "x86_64-apple-ios - Rust stable 1.18.0 - xcode10 - no run/ffi tests"
+      env: TARGET=x86_64-apple-ios NORUN=1 NOCTEST=1
       rust: 1.18.0
       os: osx
       osx_image: xcode10
-    - name: "x86_64-apple-ios - Rust beta - xcode10 - no run tests"
-      env: TARGET=x86_64-apple-ios NORUN=1
+    - name: "x86_64-apple-ios - Rust beta - xcode10 - no run/ffi tests"
+      env: TARGET=x86_64-apple-ios NORUN=1 NOCTEST=1
       rust: beta
       os: osx
       osx_image: xcode10
-    - name: "x86_64-apple-ios - Rust nightly - xcode10 - no run tests"
-      env: TARGET=x86_64-apple-ios NORUN=1
+    - name: "x86_64-apple-ios - Rust nightly - xcode10 - no run/ffi tests"
+      env: TARGET=x86_64-apple-ios NORUN=1 NOCTEST=1
       rust: nightly
       os: osx
       osx_image: xcode10
-    - name: "x86_64-apple-ios - Rust nightly - xcode9.4 - no run tests"
-      env: TARGET=x86_64-apple-ios NORUN=1
+    - name: "x86_64-apple-ios - Rust nightly - xcode9.4 - no run/ffi tests"
+      env: TARGET=x86_64-apple-ios NORUN=1 NOCTEST=1
       rust: nightly
       os: osx
       osx_image: xcode9.4
-    - name: "x86_64-apple-ios - Rust nightly - xcode8.3 - no run tests"
-      env: TARGET=x86_64-apple-ios NORUN=1
+    - name: "x86_64-apple-ios - Rust nightly - xcode8.3 - no run/ffi tests"
+      env: TARGET=x86_64-apple-ios NORUN=1 NOCTEST=1
       rust: nightly
       os: osx
       osx_image: xcode8.3
@@ -114,29 +114,24 @@ matrix:
       os: osx
       osx_image: xcode6.4
 
-    # i386-apple-ios
-    - name: "i386-apple-ios - Rust stable 1.18.0 - xcode10 - no run tests"
-      env: TARGET=i386-apple-ios NORUN=1
+    # i386-apple-ios (deprecated in xcode10)
+    - name: "i386-apple-ios - Rust stable 1.18.0 - xcode9.4 - no run/ffi tests"
+      env: TARGET=i386-apple-ios NORUN=1 NOCTEST=1
       rust: 1.18.0
       os: osx
-      osx_image: xcode10
-    - name: "i386-apple-ios - Rust beta - xcode10 - no run tests"
-      env: TARGET=i386-apple-ios NORUN=1
+      osx_image: xcode9.4
+    - name: "i386-apple-ios - Rust beta - xcode9.4 - no run/ffi tests"
+      env: TARGET=i386-apple-ios NORUN=1 NOCTEST=1
       rust: beta
       os: osx
-      osx_image: xcode10
-    - name: "i386-apple-ios - Rust nightly - xcode10 - no run tests"
-      env: TARGET=i386-apple-ios NORUN=1
-      rust: nightly
-      os: osx
-      osx_image: xcode10
-    - name: "i386-apple-ios - Rust nightly - xcode9.4 - no run tests"
-      env: TARGET=i386-apple-ios NORUN=1
+      osx_image: xcode9.4
+    - name: "i386-apple-ios - Rust nightly - xcode9.4 - no run/ffi tests"
+      env: TARGET=i386-apple-ios NORUN=1 NOCTEST=1
       rust: nightly
       os: osx
       osx_image: xcode9.4
-    - name: "i386-apple-ios - Rust nightly - xcode8.3 - no run tests"
-      env: TARGET=i386-apple-ios NORUN=1
+    - name: "i386-apple-ios - Rust nightly - xcode8.3 - no run/ffi tests"
+      env: TARGET=i386-apple-ios NORUN=1 NOCTEST=1
       rust: nightly
       os: osx
       osx_image: xcode8.3

--- a/README.md
+++ b/README.md
@@ -17,16 +17,16 @@ would have **undefined behavior**.
 
 The following table describes the current CI set-up:
 
-| Target                | Min. Rust |   XCode   | build | ctest | run |
-|-----------------------|-----------|-----------|-------|-------|-----|
-| `x86_64-apple-darwin` |  1.13.0   | 6.4 - 9.4 | ✓     | ✓     | ✓   | 
-| `i686-apple-darwin`   |  1.13.0   | 6.4 - 9.4 | ✓     | ✓     | ✓   |
-| `i386-apple-ios`      |  1.13.0   | 6.4 - 9.2 | ✓     | ✓ [0] | -   |
-| `x86_64-apple-ios`    |  1.13.0   | 6.4 - 9.2 | ✓     | ✓ [0] | -   |
-| `armv7-apple-ios`     |  nightly  | 6.4 - 9.4 | ✓     | -     | -   |
-| `aarch64-apple-ios`   |  nightly  | 6.4 - 9.4 | ✓     | -     | -   |
+| Target                | Min. Rust | XCode         | build | ctest | run |
+|-----------------------|-----------|---------------|-------|-------|-----|
+| `x86_64-apple-darwin` | 1.13.0    | 6.4 - 10.0    | ✓     | ✓     | ✓   |
+| `i686-apple-darwin`   | 1.13.0    | 6.4 - 10.0    | ✓     | ✓     | ✓   |
+| `i386-apple-ios`      | 1.13.0    | 6.4 - 9.4 [0] | ✓     | -     | -   |
+| `x86_64-apple-ios`    | 1.13.0    | 6.4 - 10.0    | ✓     | -     | -   |
+| `armv7-apple-ios`     | nightly   | 6.4 - 10.0    | ✓     | -     | -   |
+| `aarch64-apple-ios`   | nightly   | 6.4 - 10.0    | ✓     | -     | -   |
 
-[0] `ctest` is only run on iOS for XCode 8.3 version and newer.
+[0] `i386-apple-ios` is deprecated in XCode 10.0.
 
 [travis_ci]: https://travis-ci.org/fitzgen/mach
 [travis_ci_badge]: https://travis-ci.org/fitzgen/mach.png?branch=master

--- a/ci/run.sh
+++ b/ci/run.sh
@@ -9,10 +9,13 @@ echo "Running tests for target: ${TARGET}"
 export RUST_BACKTRACE=1
 export RUST_TEST_THREADS=1
 export RUST_TEST_NOCAPTURE=1
+export CARGO_INCREMENTAL=0
+export CARGO_CODEGEN_UNITS=1
+export RUSTFLAGS="-C codegen-units=1 "
 
 if [[ $TARGET == *"ios"* ]]; then
-    export RUSTFLAGS='-C link-args=-mios-simulator-version-min=7.0'
-    rustc ./ci/deploy_and_run_on_ios_simulator.rs -o ios_cargo_runner --verbose
+    RUSTFLAGS='${RUSTFLAGS} -C link-args=-mios-simulator-version-min=7.0' \
+             rustc ./ci/deploy_and_run_on_ios_simulator.rs -o ios_cargo_runner --verbose
     if [[ $TARGET == "x86_64-apple-ios" ]]; then
         export CARGO_TARGET_X86_64_APPLE_IOS_RUNNER=$(pwd)/ios_cargo_runner
     fi
@@ -25,8 +28,8 @@ rustup target add $TARGET || true
 
 # Build w/o std
 cargo clean
-cargo build --target $TARGET --verbose 2>&1 | tee build_std.txt
-cargo build --no-default-features --target $TARGET --verbose 2>&1 | tee build_no_std.txt
+cargo build --target $TARGET -vv 2>&1 | tee build_std.txt
+cargo build --no-default-features --target $TARGET -vv 2>&1 | tee build_no_std.txt
 
 # Check that the no-std builds are not linked against a libc with default
 # features or the use_std feature enabled:
@@ -39,14 +42,14 @@ cat build_std.txt | grep -q "use_std"
 
 # Runs mach's run-time tests:
 if [[ -z "$NORUN" ]]; then
-    cargo test --target $TARGET --verbose
-    cargo test --no-default-features --target $TARGET --verbose
+    cargo test --target $TARGET -vv
+    cargo test --no-default-features --target $TARGET -vv
 fi
 
 # Runs ctest to verify mach's ABI against the system libraries:
 if [[ -z "$NOCTEST" ]]; then
     if [[ $TRAVIS_RUST_VERSION == "nightly" ]]; then
-        cargo test --manifest-path mach-test/Cargo.toml --target $TARGET --verbose
-        cargo test --no-default-features --manifest-path mach-test/Cargo.toml --target $TARGET --verbose
+        cargo test --manifest-path mach-test/Cargo.toml --target $TARGET -vv
+        cargo test --no-default-features --manifest-path mach-test/Cargo.toml --target $TARGET -vv
     fi
 fi


### PR DESCRIPTION
linking and running the ios simulator tests is broken due to some issues upstream like https://github.com/rust-lang/rust/issues/55477 so we cannot check the ABIs nor run the tests anymore, and the only thing we do check is that we cross-compile correctly.