### PR TITLE
Breaking changes for 0.3 release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,14 @@ language: rust
 matrix:
   fast_finish: true
   include:
+    # x86_64-unknown-linux-gnu
+    - name: "x86_64-unknown-linux-gnu - fail"
+      env: TARGET=x86_64-unknown-linux-gnu
+      os: linux
+      rust: nightly
+      install: true
+      script: ./ci/build_fail.sh
+
     # x86_64-apple-darwin
     - name: "x86_64-apple-darwin - Rust stable 1.18.0 - xcode10"
       env: TARGET=x86_64-apple-darwin

--- a/.travis.yml
+++ b/.travis.yml
@@ -238,15 +238,20 @@ matrix:
     # Tooling
     - name: "rustfmt"
       rust: nightly
+      os: osx
+      osx_image: xcode10
       install: rustup component add rustfmt-preview
       script: cargo fmt --all -- --check
     - name: "clippy"
       rust: nightly
+      os: osx
+      osx_image: xcode10
       install: rustup component add clippy-preview
       script:
         - cargo clippy --all -- -D clippy::pedantic
         - cargo clippy --all --features=unstable -- -D clippy::pedantic
     - name: "Shellcheck"
+      install: true
       script:
         - shellcheck --version
         - shellcheck ci/*.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -243,7 +243,9 @@ matrix:
     - name: "clippy"
       rust: nightly
       install: rustup component add clippy-preview
-      script: cargo clippy --all -- -D clippy::pedantic
+      script:
+        - cargo clippy --all -- -D clippy::pedantic
+        - cargo clippy --all --features=unstable -- -D clippy::pedantic
     - name: "Shellcheck"
       script:
         - shellcheck --version

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,36 +17,43 @@ matrix:
       rust: 1.18.0
       os: osx
       osx_image: xcode10
+      install: true
     - name: "x86_64-apple-darwin - Rust beta - xcode10"
       env: TARGET=x86_64-apple-darwin
       rust: beta
       os: osx
       osx_image: xcode10
+      install: true
     - name: "x86_64-apple-darwin - Rust nightly - xcode10"
       env: TARGET=x86_64-apple-darwin
       rust: nightly
       os: osx
       osx_image: xcode10
+      install: true
     - name: "x86_64-apple-darwin - Rust nightly - xcode9.4"
       env: TARGET=x86_64-apple-darwin
       rust: nightly
       os: osx
       osx_image: xcode9.4
+      install: true
     - name: "x86_64-apple-darwin - Rust nightly - xcode8.3"
       env: TARGET=x86_64-apple-darwin
       rust: nightly
       os: osx
       osx_image: xcode8.3
+      install: true
     - name: "x86_64-apple-darwin - Rust nightly - xcode7.3"
       env: TARGET=x86_64-apple-darwin
       rust: nightly
       os: osx
       osx_image: xcode7.3
+      install: true
     - name: "x86_64-apple-darwin - Rust nightly - xcode6.4"
       env: TARGET=x86_64-apple-darwin
       rust: nightly
       os: osx
       osx_image: xcode6.4
+      install: true
 
     # i686-apple-darwin
     - name: "i686-apple-darwin - Rust stable 1.18.0 - xcode10"
@@ -237,5 +244,10 @@ matrix:
       rust: nightly
       install: rustup component add clippy-preview
       script: cargo clippy --all -- -D clippy::pedantic
+    - name: "Shellcheck"
+      script:
+        - shellcheck --version
+        - shellcheck ci/*.sh
 
+install: rustup target add "${TARGET}"
 script: ci/run.sh

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ maintenance = { status = "passively-maintained" }
 libc = { version = "0.2", default-features = false }
 
 [features]
-default = [ "use_std", "deprecated" ]
+default = [ "use_std" ]
 use_std = [ "libc/use_std" ]
 # Enables unstable / nightly-only features
 unstable = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mach"
-version = "0.2.3"
+version = "0.3.0"
 authors = ["Nick Fitzgerald <fitzgen@gmail.com>", "David Cuddeback <david.cuddeback@gmail.com>"]
 license = "BSD-2-Clause"
 description = "A Rust interface to the user-space API of the Mach 3.0 kernel that underlies OSX."
@@ -15,9 +15,8 @@ is-it-maintained-issue-resolution = { repository = "fitzgen/mach" }
 is-it-maintained-open-issues = { repository = "fitzgen/mach" }
 maintenance = { status = "passively-maintained" }
 
-[dependencies.libc]
-version = "0.2"
-default-features = false
+[target.'cfg(any(target_os = "macos", target_os = "ios"))'.dependencies]
+libc = { version = "0.2", default-features = false }
 
 [features]
 default = [ "use_std", "deprecated" ]

--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 [![Build Status][travis_ci_badge]][travis_ci] [![Latest Version]][crates.io] [![docs]][docs.rs]
 
 A Rust interface to the **user-space** API of the Mach 3.0 kernel exposed in
-`/usr/include/mach` that underlies macOS.
+`/usr/include/mach` that underlies macOS and is linked via `libSystem` (and
+`libsystem_kernel`).
 
 This library does not expose the **kernel-space** API of the Mach 3.0 kernel
 exposed in
@@ -12,6 +13,27 @@ kernel extensions you have to use something else. The user-space kernel API is
 often API-incompatible with the kernel space one, and even in the cases where
 they match, they are sometimes ABI incompatible such that using this library
 would have **undefined behavior**.
+
+# Usage
+
+Add the following to your `Cargo.toml` to conditionally include mach on those
+platforms that support it.
+
+```toml
+[target.'cfg(any(target_os = "macos", target_os = "ios"))'.dependencies.mach]
+version = "0.3"
+```
+
+The following crate features are available:
+
+* **use_std** (enabled by default): compiles the crate with `libstd` support.
+* **unstable** (disabled by default): uses `unstable` features. Some of the APIs
+  in the crate require unstable features for correctness. These APIs are only
+  available on nightly.
+* **deprecated** (disabled by default): exposes deprecated APIs that have been
+  removed from the latest versions of the MacOS SDKs. The behavior of using
+  these APIs on MacOS versions that do not support them is undefined (hopefully
+  a linker error).
 
 # Platform support
 

--- a/ci/build_fail.sh
+++ b/ci/build_fail.sh
@@ -2,6 +2,6 @@
 
 set -ex
 
-: ${TARGET?"The TARGET environment variable must be set."}
+: "${TARGET?The TARGET environment variable must be set.}"
 
 ! cargo build --target "${TARGET}"

--- a/ci/build_fail.sh
+++ b/ci/build_fail.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+set -ex
+
+: ${TARGET?"The TARGET environment variable must be set."}
+
+! cargo build --target "${TARGET}"

--- a/ci/run.sh
+++ b/ci/run.sh
@@ -47,6 +47,7 @@ grep -q "use_std" build_std.txt
 # Runs mach's run-time tests:
 if [ -z "$NORUN" ]; then
     cargo test --target "${TARGET}" -vv
+    cargo test --target "${TARGET}" -vv --features deprecated
     cargo test --no-default-features --target "${TARGET}" -vv
 fi
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,9 @@
     )
 )]
 
+#[cfg(not(any(target_os = "macos", target_os = "ios")))]
+compile_error!("mach requires MacOSX or iOS");
+
 #[cfg(feature = "use_std")]
 extern crate core;
 

--- a/src/task_info.rs
+++ b/src/task_info.rs
@@ -34,16 +34,8 @@ pub const TASK_DEBUG_INFO_INTERNAL: ::libc::c_uint = 29;
 pub type task_flavor_t = natural_t;
 pub type task_info_t = *mut integer_t;
 
-#[repr(C)]
-#[cfg_attr(feature = "unstable", repr(packed(4)))]
-#[cfg_attr(
-    not(feature = "unstable"),
-    deprecated(
-        since = "0.2.3",
-        note = "requires the unstable feature to avoid undefined behavior"
-    )
-)]
-#[cfg_attr(not(feature = "unstable"), allow(deprecated))]
+#[cfg(feature = "unstable")]
+#[repr(C, packed(4))]
 #[derive(Copy, Clone, Debug, Default, Hash, PartialOrd, PartialEq, Eq, Ord)]
 pub struct task_dyld_info {
     pub all_image_info_addr: mach_vm_address_t,

--- a/src/vm_region.rs
+++ b/src/vm_region.rs
@@ -18,23 +18,10 @@ pub type vm_region_recurse_info_t = *mut ::libc::c_int;
 pub type vm_region_recurse_info_64_t = *mut ::libc::c_int;
 pub type vm_region_flavor_t = ::libc::c_int;
 pub type vm_region_info_data_t = [::libc::c_int; VM_REGION_INFO_MAX as usize];
-#[cfg_attr(
-    not(feature = "unstable"),
-    deprecated(
-        since = "0.2.3",
-        note = "requires the `unstable` feature to avoid undefined behavior"
-    )
-)]
-#[cfg_attr(not(feature = "unstable"), allow(deprecated))]
+
+#[cfg(feature = "unstable")]
 pub type vm_region_basic_info_64_t = *mut vm_region_basic_info_64;
-#[cfg_attr(
-    not(feature = "unstable"),
-    deprecated(
-        since = "0.2.3",
-        note = "requires the `unstable` feature to avoid undefined behavior"
-    )
-)]
-#[cfg_attr(not(feature = "unstable"), allow(deprecated))]
+#[cfg(feature = "unstable")]
 pub type vm_region_basic_info_data_64_t = vm_region_basic_info_64;
 pub type vm_region_basic_info_t = *mut vm_region_basic_info;
 pub type vm_region_basic_info_data_t = vm_region_basic_info;
@@ -44,54 +31,19 @@ pub type vm_region_top_info_t = *mut vm_region_top_info;
 pub type vm_region_top_info_data_t = vm_region_top_info;
 pub type vm_region_submap_info_t = *mut vm_region_submap_info;
 pub type vm_region_submap_info_data_t = vm_region_submap_info;
-#[cfg_attr(
-    not(feature = "unstable"),
-    deprecated(
-        since = "0.2.3",
-        note = "requires the `unstable` feature to avoid undefined behavior"
-    )
-)]
-#[cfg_attr(not(feature = "unstable"), allow(deprecated))]
+#[cfg(feature = "unstable")]
 pub type vm_region_submap_info_64_t = *mut vm_region_submap_info_64;
-#[cfg_attr(
-    not(feature = "unstable"),
-    deprecated(
-        since = "0.2.3",
-        note = "requires the `unstable` feature to avoid undefined behavior"
-    )
-)]
-#[cfg_attr(not(feature = "unstable"), allow(deprecated))]
+#[cfg(feature = "unstable")]
 pub type vm_region_submap_info_data_64_t = vm_region_submap_info_64;
-#[cfg_attr(
-    not(feature = "unstable"),
-    deprecated(
-        since = "0.2.3",
-        note = "requires the `unstable` feature to avoid undefined behavior"
-    )
-)]
-#[cfg_attr(not(feature = "unstable"), allow(deprecated))]
+#[cfg(feature = "unstable")]
 pub type vm_region_submap_short_info_64_t = *mut vm_region_submap_short_info_64;
-#[cfg_attr(
-    not(feature = "unstable"),
-    deprecated(
-        since = "0.2.3",
-        note = "requires the `unstable` feature to avoid undefined behavior"
-    )
-)]
-#[cfg_attr(not(feature = "unstable"), allow(deprecated))]
+#[cfg(feature = "unstable")]
 pub type vm_region_submap_short_info_data_64_t = vm_region_submap_short_info_64;
 pub type vm_page_info_t = *mut ::libc::c_int;
 pub type vm_page_info_flavor_t = ::libc::c_int;
 pub type vm_page_info_basic_t = *mut vm_page_info_basic;
 pub type vm_page_info_basic_data_t = vm_page_info_basic;
-#[cfg_attr(
-    not(feature = "unstable"),
-    deprecated(
-        since = "0.2.3",
-        note = "requires the `unstable` feature to avoid undefined behavior"
-    )
-)]
-#[cfg_attr(not(feature = "unstable"), allow(deprecated))]
+#[cfg(feature = "unstable")]
 pub type mach_vm_read_entry_t = [mach_vm_read_entry; VM_MAP_ENTRY_MAX as usize];
 
 pub const VM_REGION_INFO_MAX: ::libc::c_int = (1 << 10);
@@ -112,16 +64,8 @@ pub const SM_TRUESHARED: ::libc::c_uchar = 5;
 pub const SM_PRIVATE_ALIASED: ::libc::c_uchar = 6;
 pub const SM_SHARED_ALIASED: ::libc::c_uchar = 7;
 
-#[repr(C)]
-#[cfg_attr(feature = "unstable", repr(packed(4)))]
-#[cfg_attr(
-    not(feature = "unstable"),
-    deprecated(
-        since = "0.2.3",
-        note = "requires the unstable feature to avoid undefined behavior"
-    )
-)]
-#[cfg_attr(not(feature = "unstable"), allow(deprecated))]
+#[cfg(feature = "unstable")]
+#[repr(C, packed(4))]
 #[derive(Copy, Clone, Debug, Default, Hash, PartialOrd, PartialEq, Eq, Ord)]
 pub struct vm_region_basic_info_64 {
     pub protection: vm_prot_t,
@@ -134,14 +78,7 @@ pub struct vm_region_basic_info_64 {
     pub user_wired_count: ::libc::c_ushort,
 }
 
-#[cfg_attr(
-    not(feature = "unstable"),
-    deprecated(
-        since = "0.2.3",
-        note = "requires the `unstable` feature to avoid undefined behavior"
-    )
-)]
-#[cfg_attr(not(feature = "unstable"), allow(deprecated))]
+#[cfg(feature = "unstable")]
 impl vm_region_basic_info_64 {
     pub fn count() -> mach_msg_type_number_t {
         (mem::size_of::<Self>() / mem::size_of::<::libc::c_int>()) as mach_msg_type_number_t
@@ -233,16 +170,8 @@ impl vm_region_submap_info {
     }
 }
 
-#[repr(C)]
-#[cfg_attr(feature = "unstable", repr(packed(4)))]
-#[cfg_attr(
-    not(feature = "unstable"),
-    deprecated(
-        since = "0.2.3",
-        note = "requires the `unstable` feature to avoid undefined behavior"
-    )
-)]
-#[cfg_attr(not(feature = "unstable"), allow(deprecated))]
+#[cfg(feature = "unstable")]
+#[repr(C, packed(4))]
 #[derive(Copy, Clone, Debug, Default, Hash, PartialOrd, PartialEq, Eq, Ord)]
 pub struct vm_region_submap_info_64 {
     pub protection: vm_prot_t,
@@ -265,30 +194,15 @@ pub struct vm_region_submap_info_64 {
     pub pages_reusable: ::libc::c_uint,
 }
 
-#[cfg_attr(
-    not(feature = "unstable"),
-    deprecated(
-        since = "0.2.3",
-        note = "requires the `unstable` feature to avoid undefined behavior"
-    )
-)]
-#[cfg_attr(not(feature = "unstable"), allow(deprecated))]
+#[cfg(feature = "unstable")]
 impl vm_region_submap_info_64 {
     pub fn count() -> mach_msg_type_number_t {
         (mem::size_of::<Self>() / mem::size_of::<::libc::c_int>()) as mach_msg_type_number_t
     }
 }
 
-#[repr(C)]
-#[cfg_attr(feature = "unstable", repr(packed(4)))]
-#[cfg_attr(
-    not(feature = "unstable"),
-    deprecated(
-        since = "0.2.3",
-        note = "requires the `unstable` feature to avoid undefined behavior"
-    )
-)]
-#[cfg_attr(not(feature = "unstable"), allow(deprecated))]
+#[cfg(feature = "unstable")]
+#[repr(C, packed(4))]
 #[derive(Copy, Clone, Debug, Default, Hash, PartialOrd, PartialEq, Eq, Ord)]
 pub struct vm_region_submap_short_info_64 {
     pub protection: vm_prot_t,
@@ -306,14 +220,7 @@ pub struct vm_region_submap_short_info_64 {
     pub user_wired_count: ::libc::c_ushort,
 }
 
-#[cfg_attr(
-    not(feature = "unstable"),
-    deprecated(
-        since = "0.2.3",
-        note = "requires the `unstable` feature to avoid undefined behavior"
-    )
-)]
-#[cfg_attr(not(feature = "unstable"), allow(deprecated))]
+#[cfg(feature = "unstable")]
 impl vm_region_submap_short_info_64 {
     pub fn count() -> mach_msg_type_number_t {
         (mem::size_of::<Self>() / mem::size_of::<::libc::c_int>()) as mach_msg_type_number_t
@@ -337,16 +244,8 @@ impl vm_page_info_basic {
     }
 }
 
-#[repr(C)]
-#[cfg_attr(feature = "unstable", repr(packed(4)))]
-#[cfg_attr(
-    not(feature = "unstable"),
-    deprecated(
-        since = "0.2.3",
-        note = "requires the `unstable` feature to avoid undefined behavior"
-    )
-)]
-#[cfg_attr(not(feature = "unstable"), allow(deprecated))]
+#[cfg(feature = "unstable")]
+#[repr(C, packed(4))]
 #[derive(Copy, Clone, Debug, Default, Hash, PartialOrd, PartialEq, Eq, Ord)]
 pub struct mach_vm_read_entry {
     pub address: mach_vm_address_t,


### PR DESCRIPTION
This PR contains two breaking changes:

* `mach` currently silently compiles (and fails to link) on unsupported platforms: this PR changes that to a hard but nice error message ("mach requires MacOSX or iOS"). 

* APIs that require `unstable` for correctness were deprecated from the "default" build in 0.2 and are now only available behind the `unstable` feature which requires nightly Rust.