### PR TITLE
Add mach/mach_time.h support and update features and deps

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,9 +12,9 @@ matrix:
       script: ./ci/build_fail.sh
 
     # x86_64-apple-darwin
-    - name: "x86_64-apple-darwin - Rust stable 1.18.0 - xcode10"
+    - name: "x86_64-apple-darwin - Rust stable 1.33.0 - xcode10"
       env: TARGET=x86_64-apple-darwin
-      rust: 1.18.0
+      rust: 1.33.0
       os: osx
       osx_image: xcode10
       install: true
@@ -56,9 +56,9 @@ matrix:
       install: true
 
     # i686-apple-darwin
-    - name: "i686-apple-darwin - Rust stable 1.18.0 - xcode10"
+    - name: "i686-apple-darwin - Rust stable 1.33.0 - xcode10"
       env: TARGET=i686-apple-darwin
-      rust: 1.18.0
+      rust: 1.33.0
       os: osx
       osx_image: xcode10
     - name: "i686-apple-darwin - Rust beta - xcode10"
@@ -93,9 +93,9 @@ matrix:
       osx_image: xcode6.4
 
     # x86_64-apple-ios
-    - name: "x86_64-apple-ios - Rust stable 1.18.0 - xcode10 - no run/ffi tests"
+    - name: "x86_64-apple-ios - Rust stable 1.33.0 - xcode10 - no run/ffi tests"
       env: TARGET=x86_64-apple-ios NORUN=1 NOCTEST=1
-      rust: 1.18.0
+      rust: 1.33.0
       os: osx
       osx_image: xcode10
     - name: "x86_64-apple-ios - Rust beta - xcode10 - no run/ffi tests"
@@ -130,9 +130,9 @@ matrix:
       osx_image: xcode6.4
 
     # i386-apple-ios (deprecated in xcode10)
-    - name: "i386-apple-ios - Rust stable 1.18.0 - xcode9.4 - no run/ffi tests"
+    - name: "i386-apple-ios - Rust stable 1.33.0 - xcode9.4 - no run/ffi tests"
       env: TARGET=i386-apple-ios NORUN=1 NOCTEST=1
-      rust: 1.18.0
+      rust: 1.33.0
       os: osx
       osx_image: xcode9.4
     - name: "i386-apple-ios - Rust beta - xcode9.4 - no run/ffi tests"
@@ -162,9 +162,9 @@ matrix:
       osx_image: xcode6.4
 
     # aarch64-apple-ios
-    - name: "aarch64-apple-ios - Rust stable 1.18.0 - xcode10 - no run/ffi tests"
+    - name: "aarch64-apple-ios - Rust stable 1.33.0 - xcode10 - no run/ffi tests"
       env: TARGET=aarch64-apple-ios NORUN=1 NOCTEST=1
-      rust: 1.18.0
+      rust: 1.33.0
       os: osx
       osx_image: xcode10
     - name: "aarch64-apple-ios - Rust beta - xcode10 - no run/ffi tests"
@@ -199,9 +199,9 @@ matrix:
       osx_image: xcode6.4
 
     # armv7-apple-ios
-    - name: "armv7-apple-ios - Rust stable 1.18.0 - xcode10 - no run/ffi tests"
+    - name: "armv7-apple-ios - Rust stable 1.33.0 - xcode10 - no run/ffi tests"
       env: TARGET=armv7-apple-ios NORUN=1 NOCTEST=1
-      rust: 1.18.0
+      rust: 1.33.0
       os: osx
       osx_image: xcode10
     - name: "armv7-apple-ios - Rust beta - xcode10 - no run/ffi tests"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ repository = "https://github.com/fitzgen/mach"
 readme = "README.md"
 keywords = ["kernel", "macos", "darwin"]
 categories = ["api-bindings", "external-ffi-bindings", "no-std", "os"]
+edition = "2015"
 
 [badges]
 travis-ci = { repository = "fitzgen/mach" }
@@ -19,10 +20,8 @@ maintenance = { status = "passively-maintained" }
 libc = { version = "0.2", default-features = false }
 
 [features]
-default = [ "use_std" ]
-use_std = [ "libc/use_std" ]
-# Enables unstable / nightly-only features
-unstable = []
+default = [ "std" ]
+std = [ "libc/std" ]
 # Enables deprecated and removed APIs.
 deprecated = []
 

--- a/README.md
+++ b/README.md
@@ -26,10 +26,7 @@ version = "0.3"
 
 The following crate features are available:
 
-* **use_std** (enabled by default): compiles the crate with `libstd` support.
-* **unstable** (disabled by default): uses `unstable` features. Some of the APIs
-  in the crate require unstable features for correctness. These APIs are only
-  available on nightly.
+* **std** (enabled by default): compiles the crate with `libstd` support.
 * **deprecated** (disabled by default): exposes deprecated APIs that have been
   removed from the latest versions of the MacOS SDKs. The behavior of using
   these APIs on MacOS versions that do not support them is undefined (hopefully
@@ -41,10 +38,10 @@ The following table describes the current CI set-up:
 
 | Target                | Min. Rust | XCode         | build | ctest | run |
 |-----------------------|-----------|---------------|-------|-------|-----|
-| `x86_64-apple-darwin` | 1.13.0    | 6.4 - 10.0    | ✓     | ✓     | ✓   |
-| `i686-apple-darwin`   | 1.13.0    | 6.4 - 10.0    | ✓     | ✓     | ✓   |
-| `i386-apple-ios`      | 1.13.0    | 6.4 - 9.4 [0] | ✓     | -     | -   |
-| `x86_64-apple-ios`    | 1.13.0    | 6.4 - 10.0    | ✓     | -     | -   |
+| `x86_64-apple-darwin` | 1.33.0    | 6.4 - 10.0    | ✓     | ✓     | ✓   |
+| `i686-apple-darwin`   | 1.33.0    | 6.4 - 10.0    | ✓     | ✓     | ✓   |
+| `i386-apple-ios`      | 1.33.0    | 6.4 - 9.4 [0] | ✓     | -     | -   |
+| `x86_64-apple-ios`    | 1.33.0    | 6.4 - 10.0    | ✓     | -     | -   |
 | `armv7-apple-ios`     | nightly   | 6.4 - 10.0    | ✓     | -     | -   |
 | `aarch64-apple-ios`   | nightly   | 6.4 - 10.0    | ✓     | -     | -   |
 

--- a/ci/run.sh
+++ b/ci/run.sh
@@ -36,11 +36,11 @@ cargo build --target "${TARGET}" -vv 2>&1 | tee build_std.txt
 cargo build --no-default-features --target "${TARGET}" -vv 2>&1 | tee build_no_std.txt
 
 # Check that the no-std builds are not linked against a libc with default
-# features or the use_std feature enabled:
+# features or the std feature enabled:
 grep -q "default" build_std.txt
-grep -q "use_std" build_std.txt
+grep -q "std" build_std.txt
 ! grep -q "default" build_no_std.txt
-! grep -q "use_std" build_no_std.txt
+! grep -q "std" build_no_std.txt
 # Make sure that the resulting build contains no std symbols
 ! find target/ -name "*.rlib" -exec nm {} \; | grep "std"
 

--- a/mach-test/Cargo.toml
+++ b/mach-test/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["gnzlbg <gonzalobg88@gmail.com>"]
 build = "build.rs"
 
 [dependencies]
-mach = { path = "..", features = ["unstable"] }
+mach = { path = ".." }
 libc = "0.2"
 
 [build-dependencies]

--- a/mach-test/build.rs
+++ b/mach-test/build.rs
@@ -44,6 +44,12 @@ fn main() {
 
     let mut cfg = ctest::TestGenerator::new();
 
+    // Older Xcode versions fail with:
+    // error: unknown warning option '-Wno-address-of-packed-member'
+    if xcode.0 < 8 {
+        cfg.flag("-Wno-unknown-warning-option");
+    }
+
     // Include the header files where the C APIs are defined
     cfg.header("mach/boolean.h")
         .header("bootstrap.h")

--- a/mach-test/build.rs
+++ b/mach-test/build.rs
@@ -312,7 +312,8 @@ fn main() {
         | "dyld_kernel_image_info"
         | "dyld_kernel_process_info"
         | "mach_timespec"
-        | "mach_vm_read_entry" => format!("struct {}", ty),
+        | "mach_vm_read_entry"
+        | "mach_timebase_info" => format!("struct {}", ty),
         _ if is_struct => format!("{}", ty),
         _ => ty.to_string(),
     });

--- a/mach-test/build.rs
+++ b/mach-test/build.rs
@@ -196,8 +196,9 @@ fn main() {
             "mach_task_self" | "current_task" => true,
 
             // These are not available in previous MacOSX versions:
-            "mach_continuous_time" |
-            "mach_continuous_approximate_time" if xcode < Xcode(8, 0) => true,
+            "mach_continuous_time" | "mach_continuous_approximate_time" if xcode < Xcode(8, 0) => {
+                true
+            }
             _ => false,
         }
     });

--- a/mach-test/build.rs
+++ b/mach-test/build.rs
@@ -196,7 +196,8 @@ fn main() {
             "mach_task_self" | "current_task" => true,
 
             // These are not available in previous MacOSX versions:
-            "mach_continuous_time" if xcode < Xcode(8, 0) => true,
+            "mach_continuous_time" |
+            "mach_continuous_approximate_time" if xcode < Xcode(8, 0) => true,
             _ => false,
         }
     });

--- a/mach-test/build.rs
+++ b/mach-test/build.rs
@@ -189,11 +189,14 @@ fn main() {
         }
     });
 
-    cfg.skip_fn(|s| {
+    cfg.skip_fn(move |s| {
         match s {
             // mac_task_self and current_tasl are not functions, but macro that map to the
             // mask_task_self_ static variable:
             "mach_task_self" | "current_task" => true,
+
+            // These are not available in previous MacOSX versions:
+            "mach_continuous_time" if xcode < Xcode(8, 0) => true,
             _ => false,
         }
     });

--- a/mach-test/test/main.rs
+++ b/mach-test/test/main.rs
@@ -15,6 +15,7 @@ use mach::exception_types::*;
 use mach::kern_return::*;
 use mach::mach_init::*;
 use mach::mach_port::*;
+use mach::mach_time::*;
 use mach::mach_types::*;
 use mach::memory_object_types::*;
 use mach::message::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,24 +1,22 @@
 #![allow(non_camel_case_types)]
 #![allow(non_upper_case_globals)]
-#![cfg_attr(not(feature = "use_std"), no_std)]
-#![cfg_attr(feature = "unstable", feature(repr_packed))]
-#![cfg_attr(
-    feature = "cargo-clippy",
-    allow(
-        clippy::stutter,
-        clippy::cast_sign_loss,
-        clippy::cast_possible_truncation,
-        clippy::trivially_copy_pass_by_ref
-    )
+#![cfg_attr(not(feature = "std"), no_std)]
+#![allow(
+    clippy::stutter,
+    clippy::cast_sign_loss,
+    clippy::cast_possible_truncation,
+    clippy::trivially_copy_pass_by_ref
 )]
 
 #[cfg(not(any(target_os = "macos", target_os = "ios")))]
 compile_error!("mach requires MacOSX or iOS");
 
-#[cfg(feature = "use_std")]
+#[cfg(feature = "std")]
 extern crate core;
 
 extern crate libc;
+
+use core::mem;
 
 pub mod boolean;
 pub mod bootstrap;
@@ -33,6 +31,7 @@ pub mod exception_types;
 pub mod kern_return;
 pub mod mach_init;
 pub mod mach_port;
+pub mod mach_time;
 pub mod mach_types;
 pub mod memory_object_types;
 pub mod message;

--- a/src/mach_time.rs
+++ b/src/mach_time.rs
@@ -1,0 +1,20 @@
+//! This module corresponds to `mach/mach_time.h`
+use kern_return::kern_return_t;
+pub type mach_timebase_info_t = *mut mach_timebase_info;
+pub type mach_timebase_info_data_t = mach_timebase_info;
+
+#[repr(C)]
+#[derive(Copy, Clone, Debug, Default, Hash, PartialOrd, PartialEq, Eq, Ord)]
+pub struct mach_timebase_info {
+    pub numer: u32,
+    pub denom: u32,
+}
+
+extern "C" {
+    pub fn mach_timebase_info(info: mach_timebase_info_t) -> kern_return_t;
+    pub fn mach_wait_until(deadline: u64) -> kern_return_t;
+    pub fn mach_absolute_time() -> u64;
+    pub fn mach_approximate_time() -> u64;
+    pub fn mach_continuous_time() -> u64;
+    pub fn mach_continuous_approximate_time() -> u64;
+}

--- a/src/structs.rs
+++ b/src/structs.rs
@@ -1,7 +1,6 @@
 //! This module corresponds to `mach/_structs.h`.
 
-use core::mem;
-
+use mem;
 use message::mach_msg_type_number_t;
 
 #[repr(C)]

--- a/src/task_info.rs
+++ b/src/task_info.rs
@@ -1,6 +1,7 @@
 //! This module roughly corresponds to `mach/task_info.h`.
 
 use vm_types::{integer_t, mach_vm_address_t, mach_vm_size_t, natural_t};
+
 pub const TASK_INFO_MAX: ::libc::c_uint = 1024;
 pub const TASK_BASIC_INFO_32: ::libc::c_uint = 4;
 pub const TASK_BASIC2_INFO_32: ::libc::c_uint = 6;
@@ -34,7 +35,6 @@ pub const TASK_DEBUG_INFO_INTERNAL: ::libc::c_uint = 29;
 pub type task_flavor_t = natural_t;
 pub type task_info_t = *mut integer_t;
 
-#[cfg(feature = "unstable")]
 #[repr(C, packed(4))]
 #[derive(Copy, Clone, Debug, Default, Hash, PartialOrd, PartialEq, Eq, Ord)]
 pub struct task_dyld_info {

--- a/src/traps.rs
+++ b/src/traps.rs
@@ -1,5 +1,4 @@
 //! This module corresponds to `mach/mach_traps.h`.
-
 use kern_return::kern_return_t;
 use port::{mach_port_name_t, mach_port_t};
 

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -11,6 +11,7 @@ use vm_behavior::vm_behavior_t;
 use vm_inherit::vm_inherit_t;
 use vm_prot::vm_prot_t;
 use vm_purgable::vm_purgable_t;
+use vm_region::mach_vm_read_entry_t;
 use vm_region::{
     vm_page_info_flavor_t, vm_page_info_t, vm_region_flavor_t, vm_region_info_t,
     vm_region_recurse_info_t,
@@ -20,9 +21,6 @@ use vm_types::{
     integer_t, mach_vm_address_t, mach_vm_offset_t, mach_vm_size_t, natural_t, vm_map_t,
     vm_offset_t, vm_size_t,
 };
-
-#[cfg(feature = "unstable")]
-use vm_region::mach_vm_read_entry_t;
 
 extern "C" {
     pub fn mach_vm_allocate(
@@ -61,7 +59,6 @@ extern "C" {
         dataCnt: *mut mach_msg_type_number_t,
     ) -> kern_return_t;
 
-    #[cfg(feature = "unstable")]
     pub fn mach_vm_read_list(
         target_task: vm_task_entry_t,
         data_list: mach_vm_read_entry_t,
@@ -222,10 +219,9 @@ mod tests {
         }
     }
 
-    #[cfg(feature = "unstable")]
     #[test]
     fn mach_vm_region_sanity() {
-        use core::mem;
+        use mem;
         use vm_prot::{VM_PROT_EXECUTE, VM_PROT_READ};
         use vm_region::{vm_region_basic_info_64, VM_REGION_BASIC_INFO_64};
         unsafe {

--- a/src/vm_region.rs
+++ b/src/vm_region.rs
@@ -1,8 +1,7 @@
 //! This module roughly corresponds to `mach/vm_region.h`.
 
-use core::mem;
-
 use boolean::boolean_t;
+use mem;
 use memory_object_types::{memory_object_offset_t, vm_object_id_t};
 use message::mach_msg_type_number_t;
 use vm_behavior::vm_behavior_t;
@@ -10,7 +9,7 @@ use vm_inherit::vm_inherit_t;
 use vm_prot::vm_prot_t;
 use vm_types::{mach_vm_address_t, mach_vm_size_t};
 
-pub type vm32_object_id_t = ::libc::uint32_t;
+pub type vm32_object_id_t = u32;
 
 pub type vm_region_info_t = *mut ::libc::c_int;
 pub type vm_region_info_64_t = *mut ::libc::c_int;
@@ -19,9 +18,7 @@ pub type vm_region_recurse_info_64_t = *mut ::libc::c_int;
 pub type vm_region_flavor_t = ::libc::c_int;
 pub type vm_region_info_data_t = [::libc::c_int; VM_REGION_INFO_MAX as usize];
 
-#[cfg(feature = "unstable")]
 pub type vm_region_basic_info_64_t = *mut vm_region_basic_info_64;
-#[cfg(feature = "unstable")]
 pub type vm_region_basic_info_data_64_t = vm_region_basic_info_64;
 pub type vm_region_basic_info_t = *mut vm_region_basic_info;
 pub type vm_region_basic_info_data_t = vm_region_basic_info;
@@ -31,19 +28,14 @@ pub type vm_region_top_info_t = *mut vm_region_top_info;
 pub type vm_region_top_info_data_t = vm_region_top_info;
 pub type vm_region_submap_info_t = *mut vm_region_submap_info;
 pub type vm_region_submap_info_data_t = vm_region_submap_info;
-#[cfg(feature = "unstable")]
 pub type vm_region_submap_info_64_t = *mut vm_region_submap_info_64;
-#[cfg(feature = "unstable")]
 pub type vm_region_submap_info_data_64_t = vm_region_submap_info_64;
-#[cfg(feature = "unstable")]
 pub type vm_region_submap_short_info_64_t = *mut vm_region_submap_short_info_64;
-#[cfg(feature = "unstable")]
 pub type vm_region_submap_short_info_data_64_t = vm_region_submap_short_info_64;
 pub type vm_page_info_t = *mut ::libc::c_int;
 pub type vm_page_info_flavor_t = ::libc::c_int;
 pub type vm_page_info_basic_t = *mut vm_page_info_basic;
 pub type vm_page_info_basic_data_t = vm_page_info_basic;
-#[cfg(feature = "unstable")]
 pub type mach_vm_read_entry_t = [mach_vm_read_entry; VM_MAP_ENTRY_MAX as usize];
 
 pub const VM_REGION_INFO_MAX: ::libc::c_int = (1 << 10);
@@ -64,7 +56,6 @@ pub const SM_TRUESHARED: ::libc::c_uchar = 5;
 pub const SM_PRIVATE_ALIASED: ::libc::c_uchar = 6;
 pub const SM_SHARED_ALIASED: ::libc::c_uchar = 7;
 
-#[cfg(feature = "unstable")]
 #[repr(C, packed(4))]
 #[derive(Copy, Clone, Debug, Default, Hash, PartialOrd, PartialEq, Eq, Ord)]
 pub struct vm_region_basic_info_64 {
@@ -78,7 +69,6 @@ pub struct vm_region_basic_info_64 {
     pub user_wired_count: ::libc::c_ushort,
 }
 
-#[cfg(feature = "unstable")]
 impl vm_region_basic_info_64 {
     pub fn count() -> mach_msg_type_number_t {
         (mem::size_of::<Self>() / mem::size_of::<::libc::c_int>()) as mach_msg_type_number_t
@@ -93,7 +83,7 @@ pub struct vm_region_basic_info {
     pub inheritance: vm_inherit_t,
     pub shared: boolean_t,
     pub reserved: boolean_t,
-    pub offset: ::libc::uint32_t,
+    pub offset: u32,
     pub behavior: vm_behavior_t,
     pub user_wired_count: ::libc::c_ushort,
 }
@@ -148,7 +138,7 @@ pub struct vm_region_submap_info {
     pub protection: vm_prot_t,
     pub max_protection: vm_prot_t,
     pub inheritance: vm_inherit_t,
-    pub offset: ::libc::uint32_t,
+    pub offset: u32,
     pub user_tag: ::libc::c_uint,
     pub pages_resident: ::libc::c_uint,
     pub pages_shared_now_private: ::libc::c_uint,
@@ -170,7 +160,6 @@ impl vm_region_submap_info {
     }
 }
 
-#[cfg(feature = "unstable")]
 #[repr(C, packed(4))]
 #[derive(Copy, Clone, Debug, Default, Hash, PartialOrd, PartialEq, Eq, Ord)]
 pub struct vm_region_submap_info_64 {
@@ -194,14 +183,12 @@ pub struct vm_region_submap_info_64 {
     pub pages_reusable: ::libc::c_uint,
 }
 
-#[cfg(feature = "unstable")]
 impl vm_region_submap_info_64 {
     pub fn count() -> mach_msg_type_number_t {
         (mem::size_of::<Self>() / mem::size_of::<::libc::c_int>()) as mach_msg_type_number_t
     }
 }
 
-#[cfg(feature = "unstable")]
 #[repr(C, packed(4))]
 #[derive(Copy, Clone, Debug, Default, Hash, PartialOrd, PartialEq, Eq, Ord)]
 pub struct vm_region_submap_short_info_64 {
@@ -220,7 +207,6 @@ pub struct vm_region_submap_short_info_64 {
     pub user_wired_count: ::libc::c_ushort,
 }
 
-#[cfg(feature = "unstable")]
 impl vm_region_submap_short_info_64 {
     pub fn count() -> mach_msg_type_number_t {
         (mem::size_of::<Self>() / mem::size_of::<::libc::c_int>()) as mach_msg_type_number_t
@@ -244,7 +230,6 @@ impl vm_page_info_basic {
     }
 }
 
-#[cfg(feature = "unstable")]
 #[repr(C, packed(4))]
 #[derive(Copy, Clone, Debug, Default, Hash, PartialOrd, PartialEq, Eq, Ord)]
 pub struct mach_vm_read_entry {


### PR DESCRIPTION
This raises the MSRV of the unreleased mach 0.3 to Rust 1.33 - this ensures that `repr(packed(N))` is always used to avoid UB. It also adds the `mach/mach_time.h` module required by libstd.