### PR TITLE
Support needed to setup call to mach::clock::clock_get_time.

### DIFF
--- a/mach-test/test/main.rs
+++ b/mach-test/test/main.rs
@@ -17,6 +17,7 @@ use mach::mach_init::*;
 use mach::mach_port::*;
 use mach::mach_time::*;
 use mach::mach_types::*;
+use mach::mach_host::*;
 use mach::memory_object_types::*;
 use mach::message::*;
 use mach::port::*;

--- a/src/clock_types.rs
+++ b/src/clock_types.rs
@@ -15,9 +15,9 @@ pub struct mach_timespec {
 }
 pub type mach_timespec_t = mach_timespec;
 
-pub const SYSTEM_CLOCK: ::libc::c_uint = 0;
-pub const CALENDAR_CLOCK: ::libc::c_uint = 1;
-pub const REALTIME_CLOCK: ::libc::c_uint = 0;
+pub const SYSTEM_CLOCK: clock_id_t = 0;
+pub const CALENDAR_CLOCK: clock_id_t = 1;
+pub const REALTIME_CLOCK: clock_id_t = 0;
 
 pub const CLOCK_GET_TIME_RES: ::libc::c_uint = 1;
 pub const CLOCK_ALARM_CURRES: ::libc::c_uint = 3;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,6 +38,7 @@ pub mod mach_init;
 pub mod mach_port;
 pub mod mach_time;
 pub mod mach_types;
+pub mod mach_host;
 pub mod memory_object_types;
 pub mod message;
 pub mod port;

--- a/src/mach_host.rs
+++ b/src/mach_host.rs
@@ -1,0 +1,9 @@
+//! This module corresponds to `mach/mach_host.h`
+
+use kern_return::kern_return_t;
+use mach_types::{host_t, clock_serv_t};
+use clock_types::clock_id_t;
+
+extern "C" {
+    pub fn host_get_clock_service(host: host_t, clock_id: clock_id_t, clock_serv: *mut clock_serv_t) -> kern_return_t;
+}

--- a/src/mach_init.rs
+++ b/src/mach_init.rs
@@ -1,9 +1,14 @@
 //! This module corresponds to `mach/mach_init.h`.
 
-use mach_types::thread_port_t;
+use port::mach_port_t;
+use mach_types::{thread_port_t, host_t};
+use vm_types::vm_size_t;
+use kern_return::kern_return_t;
 
 extern "C" {
+    pub fn mach_host_self() -> mach_port_t;
     pub fn mach_thread_self() -> thread_port_t;
+    pub fn host_page_size(host: host_t, size: *mut vm_size_t) -> kern_return_t;
 }
 
 #[cfg(test)]
@@ -12,11 +17,28 @@ mod tests {
     use port::*;
 
     #[test]
+    fn mach_host_self_test() {
+        unsafe {
+            let host = mach_host_self();
+            assert!(host != 0);
+        }
+    }
+
+    #[test]
     fn mach_thread_self_test() {
         unsafe {
             let this_thread = mach_thread_self();
             assert!(this_thread != MACH_PORT_NULL);
             assert!(this_thread != MACH_PORT_DEAD);
         }
+    }
+
+    #[test]
+    fn host_page_size_test() {
+        unsafe {
+            let mut ps: vm_size_t = 0;
+            assert!(0 == host_page_size(mach_host_self(), &mut ps));
+            assert!(ps > 0);
+        };
     }
 }


### PR DESCRIPTION
Mostly this is about adding the functions `mach_host_self ` and `host_get_clock_service`. I went ahead and added `host_page_size` since that was the only function needed to complete `mach_init`. The constants for choosing clocks were defined as unsigned, but `host_get_clock_service` takes a signed type--so I used the typedef.