### PR TITLE
Add docs.rs default target

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,3 +32,6 @@ rustc-dep-of-std = ['rustc-std-workspace-core', 'libc/rustc-dep-of-std']
 
 [workspace]
 members = ["mach-test"]
+
+[package.metadata.docs.rs]
+default-target = "x86_64-apple-darwin"


### PR DESCRIPTION
Currently this crate's documentation is broken on [docs.rs](https://docs.rs/crate/mach/0.3.2) because it cannot resolve the MacOS Os dependencies. This metadata field in the Cargo.toml will inform the docs.rs build process to use a MacOS build machine. 