### PR TITLE
switch to SPDX license expression

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ authors = [
   "David Cuddeback <david.cuddeback@gmail.com>",
   "Gonzalo Brito Gadeschi <gonzalobg88@gmail.com>"
 ]
-license = "BSD-2-Clause/MIT/Apache-2.0"
+license = "BSD-2-Clause OR MIT OR Apache-2.0"
 description = "A Rust interface to the user-space API of the Mach 3.0 kernel that underlies OSX."
 repository = "https://github.com/fitzgen/mach"
 readme = "README.md"


### PR DESCRIPTION
The [docs][1] say that specifying multiple licenses with `/` was supported
at one point but is now deprecated. Notably, crates.io does not have any
mechanism to parse `/`-separated license lists, so this crate currently
shows up as BSD-2-Clause only.

[1]: https://doc.rust-lang.org/cargo/reference/manifest.html#the-license-and-license-file-fields